### PR TITLE
fix: promises.ts lint 줄 길이 초과 수정

### DIFF
--- a/infra/firebase/functions/src/functions/promises.ts
+++ b/infra/firebase/functions/src/functions/promises.ts
@@ -601,7 +601,11 @@ export const updatePromise = onCall<UpdatePromiseRequest>(
     }
 
     if (data.descriptionBlocks !== undefined) {
-      if (data.descriptionBlocks && Array.isArray(data.descriptionBlocks) && data.descriptionBlocks.length > 20) {
+      if (
+        data.descriptionBlocks &&
+        Array.isArray(data.descriptionBlocks) &&
+        data.descriptionBlocks.length > 20
+      ) {
         throw new HttpsError("invalid-argument", "설명 블록은 최대 20개까지 허용됩니다");
       }
       updateData.descriptionBlocks = data.descriptionBlocks || null;


### PR DESCRIPTION
## Summary
- `promises.ts:604` 줄 길이 초과 lint error 수정 (114자 → 80자 이내 줄바꿈)
- stage Firebase 배포 실패 원인 해결

## Test plan
- [x] `npm run lint` error 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)