### PR TITLE
feat: 일정 생성 시 자연스러운 앱 리뷰 요청

### DIFF
--- a/Projects/Clients/Sources/Clients/AppReviewClient.swift
+++ b/Projects/Clients/Sources/Clients/AppReviewClient.swift
@@ -26,6 +26,12 @@ extension AppReviewClient: TestDependencyKey {
 // MARK: - Live
 
 extension AppReviewClient: DependencyKey {
+  private enum Eligibility {
+    static let minDaysSinceFirstLaunch: TimeInterval = 7 * 24 * 3600
+    static let minSessionCount = 3
+    static let cooldownInterval: TimeInterval = 90 * 24 * 3600
+  }
+
   public static let liveValue: AppReviewClient = {
     let defaults = UserDefaults.standard
 
@@ -46,18 +52,18 @@ extension AppReviewClient: DependencyKey {
         // 조건 1: 첫 실행 후 7일
         let firstLaunch = defaults.double(forKey: AppConstants.UserDefaults.firstLaunchDate)
         guard firstLaunch > 0,
-              now.timeIntervalSince1970 - firstLaunch >= 7 * 24 * 3600 else {
+              now.timeIntervalSince1970 - firstLaunch >= Eligibility.minDaysSinceFirstLaunch else {
           return
         }
 
         // 조건 2: 세션 3회 이상
         let sessions = defaults.integer(forKey: AppConstants.UserDefaults.sessionCount)
-        guard sessions >= 3 else { return }
+        guard sessions >= Eligibility.minSessionCount else { return }
 
         // 조건 3: 마지막 요청 후 90일
         let lastRequest = defaults.double(forKey: AppConstants.UserDefaults.lastReviewRequestDate)
         if lastRequest > 0 {
-          guard now.timeIntervalSince1970 - lastRequest >= 90 * 24 * 3600 else {
+          guard now.timeIntervalSince1970 - lastRequest >= Eligibility.cooldownInterval else {
             return
           }
         }

--- a/Projects/Clients/Sources/Clients/AppReviewClient.swift
+++ b/Projects/Clients/Sources/Clients/AppReviewClient.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Dependencies
+import DependenciesMacros
+import PromisoShared
+import StoreKit
+import UIKit
+
+// MARK: - Client
+
+@DependencyClient
+public struct AppReviewClient: Sendable {
+  /// 앱 최초 실행일 기록 (이미 기록된 경우 무시)
+  public var recordFirstLaunchIfNeeded: @Sendable () -> Void
+  /// 세션 카운트 증가
+  public var incrementSessionCount: @Sendable () -> Void
+  /// 리뷰 요청 적격 여부 판단 (적격이면 요청일 기록 후 리뷰 요청)
+  public var requestReviewIfEligible: @Sendable () async -> Void
+}
+
+// MARK: - Test / Preview
+
+extension AppReviewClient: TestDependencyKey {
+  public static let testValue = Self()
+}
+
+// MARK: - Live
+
+extension AppReviewClient: DependencyKey {
+  public static let liveValue: AppReviewClient = {
+    let defaults = UserDefaults.standard
+
+    return AppReviewClient(
+      recordFirstLaunchIfNeeded: {
+        let key = AppConstants.UserDefaults.firstLaunchDate
+        if defaults.double(forKey: key) == 0 {
+          defaults.set(Date().timeIntervalSince1970, forKey: key)
+        }
+      },
+      incrementSessionCount: {
+        let key = AppConstants.UserDefaults.sessionCount
+        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+      },
+      requestReviewIfEligible: {
+        let now = Date()
+
+        // 조건 1: 첫 실행 후 7일
+        let firstLaunch = defaults.double(forKey: AppConstants.UserDefaults.firstLaunchDate)
+        guard firstLaunch > 0,
+              now.timeIntervalSince1970 - firstLaunch >= 7 * 24 * 3600 else {
+          return
+        }
+
+        // 조건 2: 세션 3회 이상
+        let sessions = defaults.integer(forKey: AppConstants.UserDefaults.sessionCount)
+        guard sessions >= 3 else { return }
+
+        // 조건 3: 마지막 요청 후 90일
+        let lastRequest = defaults.double(forKey: AppConstants.UserDefaults.lastReviewRequestDate)
+        if lastRequest > 0 {
+          guard now.timeIntervalSince1970 - lastRequest >= 90 * 24 * 3600 else {
+            return
+          }
+        }
+
+        // 적격 → 요청일 기록 + 리뷰 요청
+        defaults.set(now.timeIntervalSince1970, forKey: AppConstants.UserDefaults.lastReviewRequestDate)
+
+        await MainActor.run {
+          guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
+            return
+          }
+          SKStoreReviewController.requestReview(in: scene)
+        }
+      }
+    )
+  }()
+}
+
+// MARK: - Dependency Registration
+
+extension DependencyValues {
+  public var appReviewClient: AppReviewClient {
+    get { self[AppReviewClient.self] }
+    set { self[AppReviewClient.self] = newValue }
+  }
+}

--- a/Projects/Features/CreateScheduleFeature/Sources/Core/CreateScheduleFeature.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/Core/CreateScheduleFeature.swift
@@ -558,7 +558,7 @@ public enum CreateSchedule {
                 try? await scheduleClient.startVoteLiveActivity(id)
               },
               .run { [appReviewClient, clock] _ in
-                try? await clock.sleep(for: .seconds(2))
+                try? await clock.sleep(for: Constants.appReviewRequestDelay)
                 await appReviewClient.requestReviewIfEligible()
               }
               .cancellable(id: CancelID.appReviewDelay)
@@ -680,6 +680,7 @@ public enum CreateSchedule {
     private enum Constants {
       static let weatherForecastMaxDays = 10
       static let weatherFetchDebounceMilliseconds = 500
+      static let appReviewRequestDelay: Duration = .seconds(2)
     }
 
     private func fetchWeatherHintEffect(state: inout State, debounce: Bool = false) -> Effect<Action> {

--- a/Projects/Features/CreateScheduleFeature/Sources/Core/CreateScheduleFeature.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/Core/CreateScheduleFeature.swift
@@ -29,12 +29,14 @@ public enum CreateSchedule {
     @Dependency(\.scheduleConflictClient) var scheduleConflictClient
     @Dependency(\.userSettingsClient) var userSettingsClient
     @Dependency(\.weatherClient) var weatherClient
+    @Dependency(\.appReviewClient) var appReviewClient
 
 
     private enum CancelID: Hashable {
       case emojiSuggestDebounce
       case conflictCheckDebounce
       case weatherFetchDebounce
+      case appReviewDelay
     }
     
     @ObservableState
@@ -554,7 +556,12 @@ public enum CreateSchedule {
               .send(.delegate(.scheduleCreated(id: id))),
               .run { [scheduleClient] _ in
                 try? await scheduleClient.startVoteLiveActivity(id)
+              },
+              .run { [appReviewClient, clock] _ in
+                try? await clock.sleep(for: .seconds(2))
+                await appReviewClient.requestReviewIfEligible()
               }
+              .cancellable(id: CancelID.appReviewDelay)
             )
 
           case .createScheduleResponse(.failure(let e)):

--- a/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventFeature.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventFeature.swift
@@ -26,6 +26,7 @@ extension CreatePersonalEvent {
     @Dependency(\.scheduleConflictClient) var scheduleConflictClient
     @Dependency(\.userSettingsClient) var userSettingsClient
     @Dependency(\.weatherClient) var weatherClient
+    @Dependency(\.appReviewClient) var appReviewClient
 
     public init() {}
 
@@ -35,6 +36,7 @@ extension CreatePersonalEvent {
       case emojiDebounce
       case conflictCheckDebounce
       case weatherFetchDebounce
+      case appReviewDelay
     }
 
     // MARK: - Mode
@@ -417,13 +419,24 @@ extension CreatePersonalEvent {
 
           case .saveSuccess(let event):
             state.isSaving = false
-            let delegateAction: Action = state.mode == .create
+            let isCreate = state.mode == .create
+            let delegateAction: Action = isCreate
               ? .delegate(.eventCreated)
               : .delegate(.eventUpdated(event))
-            return .merge(
+            var effects: [Effect<Action>] = [
               .run { _ in await hapticFeedback.success() },
-              .send(delegateAction)
-            )
+              .send(delegateAction),
+            ]
+            if isCreate {
+              effects.append(
+                .run { [appReviewClient, clock] _ in
+                  try? await clock.sleep(for: .seconds(2))
+                  await appReviewClient.requestReviewIfEligible()
+                }
+                .cancellable(id: CancelID.appReviewDelay)
+              )
+            }
+            return .merge(effects)
 
           case .saveFailed(let message):
             state.isSaving = false

--- a/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventFeature.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventFeature.swift
@@ -430,7 +430,7 @@ extension CreatePersonalEvent {
             if isCreate {
               effects.append(
                 .run { [appReviewClient, clock] _ in
-                  try? await clock.sleep(for: .seconds(2))
+                  try? await clock.sleep(for: Constants.appReviewRequestDelay)
                   await appReviewClient.requestReviewIfEligible()
                 }
                 .cancellable(id: CancelID.appReviewDelay)
@@ -550,6 +550,7 @@ extension CreatePersonalEvent {
     private enum Constants {
       static let weatherForecastMaxDays = 10
       static let weatherFetchDebounceMilliseconds = 500
+      static let appReviewRequestDelay: Duration = .seconds(2)
     }
 
     private func fetchWeatherHintEffect(state: inout State, debounce: Bool = false) -> Effect<Action> {

--- a/Projects/Features/CreateScheduleFeature/Tests/Sources/CreateScheduleReducerTests.swift
+++ b/Projects/Features/CreateScheduleFeature/Tests/Sources/CreateScheduleReducerTests.swift
@@ -296,6 +296,7 @@ struct CreateScheduleReducerTests {
     } withDependencies: {
       $0.analyticsClient.logEvent = { _, _ in }
       $0.scheduleClient.startVoteLiveActivity = { _ in }
+      $0.appReviewClient.requestReviewIfEligible = { }
     }
     store.exhaustivity = .off
 

--- a/Projects/Features/CreateScheduleFeature/Tests/Sources/CreateScheduleReducerTests.swift
+++ b/Projects/Features/CreateScheduleFeature/Tests/Sources/CreateScheduleReducerTests.swift
@@ -294,6 +294,7 @@ struct CreateScheduleReducerTests {
     let store = TestStore(initialState: state) {
       CreateSchedule.Feature()
     } withDependencies: {
+      $0.continuousClock = ImmediateClock()
       $0.analyticsClient.logEvent = { _, _ in }
       $0.scheduleClient.startVoteLiveActivity = { _ in }
       $0.appReviewClient.requestReviewIfEligible = { }

--- a/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
+++ b/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
@@ -112,6 +112,7 @@ extension RootTab {
     @Dependency(\.calendarSyncClient) var calendarSyncClient
     @Dependency(\.analyticsClient) var analyticsClient
     @Dependency(\.subscriptionClient) var subscriptionClient
+    @Dependency(\.appReviewClient) var appReviewClient
 
     private enum CancelID: Hashable {
       case subscriptionStatus
@@ -315,6 +316,13 @@ extension RootTab {
             .send(.internal(.syncCalendar)),
             .send(.internal(.observeSubscriptionStatus))
           ]
+
+          effects.append(
+            .run { [appReviewClient] _ in
+              appReviewClient.recordFirstLaunchIfNeeded()
+              appReviewClient.incrementSessionCount()
+            }
+          )
 
           if !state.hasInitialCalendarSyncBeenScheduled {
             effects.append(.send(.internal(.syncCalendar)))

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -1049,5 +1049,8 @@ private extension RootTabFeatureTests {
 
     dependencies.subscriptionClient.fetchStatus = { .none }
     dependencies.subscriptionClient.unifiedStatusStream = { AsyncStream { $0.finish() } }
+
+    dependencies.appReviewClient.recordFirstLaunchIfNeeded = { }
+    dependencies.appReviewClient.incrementSessionCount = { }
   }
 }

--- a/Projects/Shared/Sources/Constants/AppConstants.swift
+++ b/Projects/Shared/Sources/Constants/AppConstants.swift
@@ -303,6 +303,15 @@ public enum AppConstants {
     /// 캘린더 기본 표시 모드 (week/month/monthExpanded)
     public static let defaultCalendarDisplayMode = "promisoDefaultCalendarDisplayMode"
 
+    // MARK: - App Review
+
+    /// 앱 최초 실행일 (TimeInterval)
+    public static let firstLaunchDate = "promisoFirstLaunchDate"
+    /// 앱 세션 카운트
+    public static let sessionCount = "promisoSessionCount"
+    /// 마지막 리뷰 요청일 (TimeInterval)
+    public static let lastReviewRequestDate = "promisoLastReviewRequestDate"
+
     // MARK: - Guide
 
     /// 캘린더 기능 가이드 본 적 있는지


### PR DESCRIPTION
## Summary
- `AppReviewClient` 신규 추가: 적격성 조건(첫 실행 7일, 세션 3회, 90일 쿨다운) 판단 후 `SKStoreReviewController.requestReview(in:)` 호출
- 그룹 일정 / 개인 일정 생성 완료 시 2초 지연 후 리뷰 요청 트리거
- `RootTabFeature.onAppear`에서 최초 실행일 기록 및 세션 카운트 증가

## Test plan
- [ ] 첫 실행 7일 미경과 시 리뷰 프롬프트가 표시되지 않는지 확인
- [ ] 세션 3회 미만일 때 리뷰 프롬프트가 표시되지 않는지 확인
- [ ] 조건 충족 시 일정 생성 완료 2초 후 시스템 리뷰 프롬프트 표시 확인
- [ ] 개인 일정 수정 모드에서는 리뷰 요청이 트리거되지 않는지 확인
- [ ] DEBUG 빌드에서 UserDefaults 값 조작으로 적격성 조건 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)