### PR TITLE
fix: admin 테스트 mock 보강으로 stage 자동 배포 수정

### DIFF
--- a/infra/firebase/functions/test/admin.test.ts
+++ b/infra/firebase/functions/test/admin.test.ts
@@ -406,6 +406,33 @@ describe("admin functions", () => {
               get: jest.fn().mockResolvedValue(
                 createMockDocument(id, usersData)
               ),
+              collection: jest.fn(() => ({
+                count: jest.fn(() => ({
+                  get: jest.fn().mockResolvedValue({
+                    data: () => ({count: 0}),
+                  }),
+                })),
+              })),
+            })),
+            orderBy: jest.fn(() => ({
+              startAfter: jest.fn(() => ({
+                limit: jest.fn((limitValue: number) => ({
+                  get: jest.fn().mockResolvedValue({
+                    docs: [...usersData.keys()]
+                      .sort()
+                      .slice(0, limitValue)
+                      .map((id) => createMockDocument(id, usersData)),
+                  }),
+                })),
+              })),
+              limit: jest.fn((limitValue: number) => ({
+                get: jest.fn().mockResolvedValue({
+                  docs: [...usersData.keys()]
+                    .sort()
+                    .slice(0, limitValue)
+                    .map((id) => createMockDocument(id, usersData)),
+                }),
+              })),
             })),
             limit: jest.fn((limitValue: number) => ({
               get: jest.fn().mockResolvedValue({
@@ -503,6 +530,12 @@ describe("admin functions", () => {
     };
     (configAdmin.firestore as any).FieldValue = {
       serverTimestamp: jest.fn(() => "__server_timestamp__"),
+    };
+    (firestoreSpy as any).FieldPath = {
+      documentId: jest.fn(() => "__document_id__"),
+    };
+    (configAdmin.firestore as any).FieldPath = {
+      documentId: jest.fn(() => "__document_id__"),
     };
 
     const functions = await import("../src/functions/admin");
@@ -845,6 +878,7 @@ describe("admin functions", () => {
 
     expect(result).toEqual({
       success: true,
+      hasMore: false,
       results: [
         {
           userId: "user-a",
@@ -853,6 +887,7 @@ describe("admin functions", () => {
           email: "alpha@promiso.app",
           groupCount: 0,
           deviceCount: 0,
+          personalEventCount: 0,
           subscriptionStatus: null,
           overrideActive: false,
         },
@@ -863,6 +898,7 @@ describe("admin functions", () => {
           email: "beta@promiso.app",
           groupCount: 0,
           deviceCount: 0,
+          personalEventCount: 0,
           subscriptionStatus: null,
           overrideActive: false,
         },
@@ -907,6 +943,7 @@ describe("admin functions", () => {
 
     expect(result).toEqual({
       success: true,
+      hasMore: false,
       results: [{
         userId: "user-a",
         name: null,
@@ -914,6 +951,7 @@ describe("admin functions", () => {
         email: "alpha@promiso.app",
         groupCount: 0,
         deviceCount: 0,
+        personalEventCount: 0,
         subscriptionStatus: "subscribed",
         overrideActive: true,
       }],
@@ -958,6 +996,7 @@ describe("admin functions", () => {
 
     expect(result).toEqual({
       success: true,
+      hasMore: false,
       results: [{
         userId: "user-b",
         name: null,
@@ -965,6 +1004,7 @@ describe("admin functions", () => {
         email: "beta@promiso.app",
         groupCount: 0,
         deviceCount: 0,
+        personalEventCount: 0,
         subscriptionStatus: null,
         overrideActive: true,
       }],
@@ -1031,6 +1071,7 @@ describe("admin functions", () => {
 
     expect(result).toEqual({
       success: true,
+      hasMore: false,
       results: [{
         userId: "target-user",
         name: "성원",
@@ -1038,6 +1079,7 @@ describe("admin functions", () => {
         email: "kswen@promiso.app",
         groupCount: 2,
         deviceCount: 2,
+        personalEventCount: 0,
         subscriptionStatus: "subscribed",
         overrideActive: true,
       }],
@@ -1128,6 +1170,7 @@ describe("admin functions", () => {
         email: "kswen@promiso.app",
         groupCount: 1,
         deviceCount: 1,
+        personalEventCount: 0,
         subscriptionStatus: "subscribed",
         overrideActive: true,
       },


### PR DESCRIPTION
## Summary
- `admin.test.ts`에 누락된 Firestore mock 3종을 추가하여 stage 자동 배포 CI 실패 해결
  - `admin.firestore.FieldPath.documentId()` mock 추가
  - users doc의 `collection("personalEvents").count().get()` subcollection mock 추가
  - users collection의 `orderBy` chain mock 추가
- 소스 코드 반환값에 맞춰 테스트 assertion에 `personalEventCount`, `hasMore` 필드 보완

## Test plan
- [x] `npm test` 전체 통과 (10 suites, 185 tests, 0 failures)
- [x] `npm run lint` error 없음
- [ ] release/v1.3.1 머지 후 자동 배포 워크플로우 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)