### PR TITLE
fix: 일정 추출 시 인접한 텍스트 블록 자동 병합

### DIFF
--- a/Projects/Clients/Sources/Clients/ScheduleExtractionClient.swift
+++ b/Projects/Clients/Sources/Clients/ScheduleExtractionClient.swift
@@ -283,8 +283,8 @@ private func parseEventModel(from data: [String: Any]) throws -> PersonalEventMo
       }
     }
     if !blocks.isEmpty {
-      event.descriptionBlocks = blocks
-      event.description = blocks.plainText
+      event.descriptionBlocks = blocks.mergingAdjacentTextBlocks()
+      event.description = event.descriptionBlocks.plainText
     }
   }
 

--- a/Projects/Shared/Sources/Models/DescriptionBlock.swift
+++ b/Projects/Shared/Sources/Models/DescriptionBlock.swift
@@ -128,4 +128,24 @@ extension Array where Element == DescriptionBlock {
       .joined(separator: "\n\n")
     return text.isEmpty ? nil : text
   }
+
+  /// 인접한 텍스트 블록을 하나로 합침
+  public func mergingAdjacentTextBlocks() -> [DescriptionBlock] {
+    guard count > 1 else { return self }
+
+    var result: [DescriptionBlock] = []
+    for block in self {
+      if case .text(let newText) = block.content,
+         let lastIndex = result.indices.last,
+         case .text(let existingText) = result[lastIndex].content {
+        result[lastIndex] = DescriptionBlock(
+          id: result[lastIndex].id,
+          content: .text(existingText + "\n\n" + newText)
+        )
+      } else {
+        result.append(block)
+      }
+    }
+    return result
+  }
 }

--- a/infra/firebase/functions/src/functions/scheduleExtraction.ts
+++ b/infra/firebase/functions/src/functions/scheduleExtraction.ts
@@ -271,6 +271,26 @@ export const extractSchedule = onCall<ExtractScheduleRequest>(
             if (block.type === "text") return !!block.content;
             return block.items && block.items.length > 0;
           });
+
+        // 인접한 텍스트 블록 병합
+        if (descriptionBlocks.length > 1) {
+          descriptionBlocks = descriptionBlocks.reduce<
+            DescriptionBlockResponse[]
+          >(
+            (acc, block) => {
+              const last = acc[acc.length - 1];
+              if (block.type === "text" && last?.type === "text") {
+                last.content =
+                  (last.content ?? "") + "\n\n" + (block.content ?? "");
+              } else {
+                acc.push({...block});
+              }
+              return acc;
+            },
+            [],
+          );
+        }
+
         if (descriptionBlocks.length === 0) descriptionBlocks = null;
       }
 


### PR DESCRIPTION
## Summary
- LLM이 문자에서 블록 추출 시 `text + list + text` 패턴으로 분리되던 인접 텍스트 블록을 하나로 병합
- 서버(Functions) + 클라이언트(iOS) 양쪽에서 방어적으로 처리
- `[DescriptionBlock].mergingAdjacentTextBlocks()` 유틸리티 추가

## Test plan
- [ ] SMS 문자 붙여넣기로 일정 추출 시 인접 텍스트 블록이 하나로 합쳐지는지 확인
- [ ] checklist/bulletList 사이의 텍스트 블록은 독립 유지되는지 확인
- [ ] 단일 블록, 빈 블록 등 엣지 케이스 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)