### PR TITLE
fix: 전체 코드 리뷰 — 보안, TCA 패턴, 컨벤션 일괄 수정

### DIFF
--- a/Projects/Clients/Sources/Clients/AnalyticsClient.swift
+++ b/Projects/Clients/Sources/Clients/AnalyticsClient.swift
@@ -5,6 +5,7 @@ import PromisoShared
 
 // MARK: - Client
 
+@DependencyClient
 public struct AnalyticsClient: Sendable {
   /// Analytics 이벤트 로깅
   public var logEvent: @Sendable (String, [String: Any]?) -> Void

--- a/Projects/Clients/Sources/Clients/AppConfigClient.swift
+++ b/Projects/Clients/Sources/Clients/AppConfigClient.swift
@@ -22,13 +22,14 @@ public enum VersionCheckResult: Equatable, Sendable {
 // MARK: - Client
 
 /// Firebase Remote Config에서 앱 설정 정보를 가져오는 클라이언트
+@DependencyClient
 public struct AppConfigClient: Sendable {
   /// 앱 설정 조회
   public var fetchConfig: @Sendable () async throws -> AppConfigModel
   /// 현재 앱 버전과 비교하여 업데이트 필요 여부 확인
-  public var checkVersion: @Sendable () async -> VersionCheckResult
+  public var checkVersion: @Sendable () async -> VersionCheckResult = { .upToDate }
   /// 캐시 초기화 후 버전 체크 (앱스토어 복귀 시 사용)
-  public var checkVersionForced: @Sendable () async -> VersionCheckResult
+  public var checkVersionForced: @Sendable () async -> VersionCheckResult = { .upToDate }
 }
 
 // MARK: - Error

--- a/Projects/Clients/Sources/Clients/AuthClient.swift
+++ b/Projects/Clients/Sources/Clients/AuthClient.swift
@@ -439,7 +439,9 @@ extension AuthClient: DependencyKey {
         do {
           let token = try await user.getIDToken()
           WidgetAuthTokenStore.save(token: token, userId: user.uid)
-        } catch {}
+        } catch {
+          AppLogger.auth.error("Widget auth token 갱신 실패: \(error.localizedDescription)")
+        }
       },
       clearWidgetAuthToken: {
         WidgetAuthTokenStore.clear()
@@ -469,7 +471,9 @@ extension AuthClient: DependencyKey {
 
           // App Group에 저장
           WidgetTokenStore.save(token: widgetToken, expiresAt: TimeInterval(expiresAt))
-        } catch {}
+        } catch {
+          AppLogger.auth.error("Widget long-lived token 발급 실패: \(error.localizedDescription)")
+        }
       },
       deleteAccount: {
         // 회원 탈퇴 - Firebase Function 호출

--- a/Projects/Clients/Sources/Clients/NotificationClient.swift
+++ b/Projects/Clients/Sources/Clients/NotificationClient.swift
@@ -6,6 +6,7 @@ import UserNotifications
 
 // MARK: - Client
 
+@DependencyClient
 public struct NotificationClient: Sendable {
   // MARK: - FCM Token Management
 

--- a/Projects/Clients/Sources/Data/DataSources/Implementations/ScheduleRemoteDataSource.swift
+++ b/Projects/Clients/Sources/Data/DataSources/Implementations/ScheduleRemoteDataSource.swift
@@ -20,10 +20,10 @@ private enum FirebaseFunctionNames {
 
 // MARK: - Date Formatter 상수
 
-/// ISO8601 DateFormatter (Seoul 타임존, 쓰기용)
-private let iso8601FormatterWithSeoulTimeZone: ISO8601DateFormatter = {
+/// ISO8601 DateFormatter (현재 타임존, 쓰기용)
+private let iso8601FormatterWithCurrentTimeZone: ISO8601DateFormatter = {
   let formatter = ISO8601DateFormatter()
-  formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+  formatter.timeZone = TimeZone.current
   formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
   return formatter
 }()
@@ -60,7 +60,7 @@ public class ScheduleRemoteDataSource: ScheduleRemoteDataSourceProtocol {
     var callableData: [String: Any] = [
       "groupId": schedule.groupId,
       "title": schedule.title,
-      "startAt": iso8601FormatterWithSeoulTimeZone.string(from: schedule.startAt),
+      "startAt": iso8601FormatterWithCurrentTimeZone.string(from: schedule.startAt),
       "minimumParticipants": schedule.minimumParticipants
     ]
 
@@ -83,7 +83,7 @@ public class ScheduleRemoteDataSource: ScheduleRemoteDataSourceProtocol {
     }
 
     if let endAt = schedule.endAt {
-      callableData["endAt"] = iso8601FormatterWithSeoulTimeZone.string(from: endAt)
+      callableData["endAt"] = iso8601FormatterWithCurrentTimeZone.string(from: endAt)
     }
 
     if let location = schedule.location, !location.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -191,7 +191,7 @@ public class ScheduleRemoteDataSource: ScheduleRemoteDataSourceProtocol {
     var callableData: [String: Any] = [
       "promiseId": schedule.id,
       "title": schedule.title,
-      "startAt": iso8601FormatterWithSeoulTimeZone.string(from: schedule.startAt),
+      "startAt": iso8601FormatterWithCurrentTimeZone.string(from: schedule.startAt),
       "minimumParticipants": schedule.minimumParticipants
     ]
 
@@ -218,7 +218,7 @@ public class ScheduleRemoteDataSource: ScheduleRemoteDataSourceProtocol {
     }
 
     if let endAt = schedule.endAt {
-      callableData["endAt"] = iso8601FormatterWithSeoulTimeZone.string(from: endAt)
+      callableData["endAt"] = iso8601FormatterWithCurrentTimeZone.string(from: endAt)
     } else {
       callableData["endAt"] = NSNull()
     }

--- a/Projects/Clients/Sources/Data/DataSources/Implementations/UserProfileRemoteDataSource.swift
+++ b/Projects/Clients/Sources/Data/DataSources/Implementations/UserProfileRemoteDataSource.swift
@@ -287,7 +287,6 @@ private extension Encodable {
   /// Encodable을 Dictionary로 변환
   func asDictionary() throws -> [String: Any] {
     let encoder = JSONEncoder()
-    encoder.outputFormatting = .prettyPrinted
     let data = try encoder.encode(self)
     guard let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
       throw UserProfileError.invalidData

--- a/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
+++ b/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
@@ -86,6 +86,7 @@ extension AppEntry {
 
     // MARK: - Action
 
+    @CasePathable
     public enum Action {
       case view(ViewAction)
       case `internal`(InternalAction)
@@ -358,9 +359,7 @@ extension AppEntry {
               )
             )
             let providerIdentifier = userModel.provider.providerTypeIdentifier
-            let personalCalendarSyncEnabled = UserDefaults.standard.bool(
-              forKey: AppConstants.UserDefaults.personalCalendarSync
-            )
+            let personalCalendarSyncEnabled = userDefaultsClient.boolForKey(AppConstants.UserDefaults.personalCalendarSync)
             analyticsClient.setUserID(userModel.id)
             analyticsClient.setUserProperty(userModel.nickname, .nickname)
             analyticsClient.setUserProperty(providerIdentifier, .authProvider)

--- a/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
+++ b/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
@@ -158,6 +158,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.stringForKey = { _ in nil }
       $0.userDefaultsClient.setString = { _, _ in }
       $0.whatsNewClient.fetchWhatsNew = { _ in nil }
@@ -306,6 +307,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.stringForKey = { _ in nil }
       $0.userDefaultsClient.setString = { _, _ in }
       $0.whatsNewClient.fetchWhatsNew = { _ in nil }
@@ -337,6 +339,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.stringForKey = { _ in nil }
       $0.userDefaultsClient.setString = { _, _ in }
       $0.whatsNewClient.fetchWhatsNew = { _ in nil }
@@ -429,6 +432,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -469,6 +473,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.setBool = { _, _ in }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
@@ -496,6 +501,7 @@ struct AppEntryFeatureTests {
       $0.analyticsClient.setUserID = { _ in }
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.setBool = { _, _ in }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)

--- a/Projects/Features/AppEntryFeature/Tests/Sources/DeeplinkRoutingTests.swift
+++ b/Projects/Features/AppEntryFeature/Tests/Sources/DeeplinkRoutingTests.swift
@@ -28,6 +28,7 @@ struct DeeplinkRoutingTests {
     } withDependencies: {
       $0.deeplinkClient.parseURL = { _ in .group(groupId: "group-123") }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -43,6 +44,7 @@ struct DeeplinkRoutingTests {
     } withDependencies: {
       $0.deeplinkClient.parseURL = { _ in .schedule(scheduleId: "schedule-1", groupId: "group-1") }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -158,6 +160,7 @@ struct DeeplinkRoutingTests {
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.stringForKey = { _ in nil }
       $0.userDefaultsClient.setString = { _, _ in }
       $0.whatsNewClient.fetchWhatsNew = { _ in nil }
@@ -264,6 +267,7 @@ struct PushNotificationDeeplinkTests {
       AppEntry.Feature()
     } withDependencies: {
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -278,6 +282,7 @@ struct PushNotificationDeeplinkTests {
       AppEntry.Feature()
     } withDependencies: {
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -350,6 +355,7 @@ struct PushNotificationDeeplinkTests {
       $0.analyticsClient.setUserProperty = { _, _ in }
       $0.analyticsClient.logEvent = { _, _ in }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.userDefaultsClient.stringForKey = { _ in nil }
       $0.userDefaultsClient.setString = { _, _ in }
       $0.whatsNewClient.fetchWhatsNew = { _ in nil }

--- a/Projects/Features/AuthFeature/Sources/AuthFeature.swift
+++ b/Projects/Features/AuthFeature/Sources/AuthFeature.swift
@@ -45,6 +45,7 @@ extension Auth {
       case delegate(Delegate)
     }
     
+    @CasePathable
     public enum View: Sendable {
       case appleLoginTapped
       case googleLoginTapped
@@ -457,11 +458,12 @@ extension Auth {
     var onComplete: ((Result<ASAuthorization, Error>) -> Void)?
     
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-      guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-            let window = windowScene.windows.first else {
-        fatalError("No window found")
+      if let windowScene = UIApplication.shared.connectedScenes
+        .first(where: { ($0 as? UIWindowScene)?.activationState == .foregroundActive }) as? UIWindowScene,
+         let window = windowScene.windows.first {
+        return window
       }
-      return window
+      return UIWindow()
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {

--- a/Projects/Features/AuthFeature/Sources/AuthFeature.swift
+++ b/Projects/Features/AuthFeature/Sources/AuthFeature.swift
@@ -460,7 +460,7 @@ extension Auth {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
       if let windowScene = UIApplication.shared.connectedScenes
         .first(where: { ($0 as? UIWindowScene)?.activationState == .foregroundActive }) as? UIWindowScene,
-         let window = windowScene.windows.first {
+         let window = windowScene.windows.first(where: \.isKeyWindow) ?? windowScene.windows.first {
         return window
       }
       return UIWindow()

--- a/Projects/Features/CalendarFeature/Sources/Feature/CalendarRootView.swift
+++ b/Projects/Features/CalendarFeature/Sources/Feature/CalendarRootView.swift
@@ -490,11 +490,15 @@ extension CalendarFeature {
 
     // MARK: - Month Mode Header
 
-    private var monthModeHeader: some View {
+    private static let monthNameFormatter: DateFormatter = {
       let formatter = DateFormatter()
       formatter.locale = LocaleManager.appLocale
       formatter.setLocalizedDateFormatFromTemplate("MMMM")
-      let monthTitle = formatter.string(from: store.currentMonth)
+      return formatter
+    }()
+
+    private var monthModeHeader: some View {
+      let monthTitle = Self.monthNameFormatter.string(from: store.currentMonth)
 
       return HStack {
         Text("\(monthTitle) \(LocalizedStrings.Schedule.schedule)")

--- a/Projects/Features/CalendarFeature/Sources/Views/ScheduleCardView.swift
+++ b/Projects/Features/CalendarFeature/Sources/Views/ScheduleCardView.swift
@@ -11,11 +11,11 @@ import PromisoShared
 extension ScheduleResponseStatus {
   var color: Color {
     switch self {
-    case .needResponse: return .yellow
-    case .expired:      return Color(UIColor.systemGray3)
-    case .responded:    return .orange
-    case .confirmed:    return .green
-    case .failed:       return Color(UIColor.systemGray3)
+    case .needResponse: return Color.pmwarning.n500
+    case .expired:      return Color.pmgray.n300
+    case .responded:    return Color.pminfo.n500
+    case .confirmed:    return Color.pmsuccess.n500
+    case .failed:       return Color.pmgray.n300
     }
   }
 

--- a/Projects/Features/CreateScheduleFeature/Sources/Views/Step3/ArrivalSharingSection.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/Views/Step3/ArrivalSharingSection.swift
@@ -149,9 +149,8 @@ struct ArrivalSharingSection: View {
         store.send(.view(.setTrackingStartMinutes(30)))
       }
     }
-    .task {
-      try? await Task.sleep(for: .seconds(1))
-      // UserDefaults에서 본 적 있는지 확인 후 처음이면 팝오버 표시
+    .onAppear {
+      // UserDefaults에서 본 적 있는지 확인 후 처음이면 팝오버 표시 (딜레이는 Reducer Effect에서 처리)
       store.send(.view(.arrivalSharingSectionAppeared))
     }
     .onChange(of: isCustomInputFocused) { _, isFocused in

--- a/Projects/Features/GroupFeature/Sources/GroupMain/GroupMainFeature.swift
+++ b/Projects/Features/GroupFeature/Sources/GroupMain/GroupMainFeature.swift
@@ -176,6 +176,7 @@ extension GroupMain {
       case view(ViewAction)
       case binding(BindingAction<State>)
       case `internal`(Internal)
+      case delegate(DelegateAction)
 
       case createSchedule(PresentationAction<CreateSchedule.Feature.Action>)
       case createGroup(PresentationAction<CreateGroup.Feature.Action>)
@@ -273,6 +274,11 @@ extension GroupMain {
         case conflictSettingsLoaded(Int)
         case fetchWeather([ScheduleModel])
         case weatherBatchResponse([String: WeatherInfo])
+      }
+
+      @CasePathable
+      public enum DelegateAction: Sendable {
+        case switchToPersonalMode
       }
     }
 
@@ -597,7 +603,8 @@ extension GroupMain {
               let summaries = state.sortedGroupsForSelection(state.currentUser.groups)
               state.allGroupSummaries = summaries
             }
-            guard let groups = state.allGroupSummaries, !groups.isEmpty else {
+
+            guard state.allGroupSummaries?.isEmpty == false else {
               // 그룹 없음 → 그룹 탭 화면 유지 (온보딩 모드)
               return .none
             }
@@ -605,8 +612,7 @@ extension GroupMain {
             return .send(.view(.createNewSchedule))
 
           case .switchToPersonalMode:
-            // RootTabFeature에서 처리
-            return .none
+            return .send(.delegate(.switchToPersonalMode))
 
           case .showGuide:
             state.isShowingGuide = true
@@ -822,8 +828,8 @@ extension GroupMain {
             }
             analyticsClient.setGroupMembershipProperties(groupSummaries)
             analyticsClient.setCalendarSyncEnabled(
-              personalEnabled: UserDefaults.standard.bool(
-                forKey: AppConstants.UserDefaults.personalCalendarSync
+              personalEnabled: userDefaultsClient.boolForKey(
+                AppConstants.UserDefaults.personalCalendarSync
               ),
               groups: groupSummaries
             )
@@ -1174,8 +1180,8 @@ extension GroupMain {
             }
             analyticsClient.setGroupMembershipProperties(summaries)
             analyticsClient.setCalendarSyncEnabled(
-              personalEnabled: UserDefaults.standard.bool(
-                forKey: AppConstants.UserDefaults.personalCalendarSync
+              personalEnabled: userDefaultsClient.boolForKey(
+                AppConstants.UserDefaults.personalCalendarSync
               ),
               groups: summaries
             )
@@ -1198,8 +1204,8 @@ extension GroupMain {
             }
             analyticsClient.setGroupMembershipProperties(summaries)
             analyticsClient.setCalendarSyncEnabled(
-              personalEnabled: UserDefaults.standard.bool(
-                forKey: AppConstants.UserDefaults.personalCalendarSync
+              personalEnabled: userDefaultsClient.boolForKey(
+                AppConstants.UserDefaults.personalCalendarSync
               ),
               groups: summaries
             )
@@ -1535,6 +1541,9 @@ extension GroupMain {
           return .none
 
         case .path:
+          return .none
+
+        case .delegate:
           return .none
 
         case .binding:

--- a/Projects/Features/GroupFeature/Sources/GroupMain/GroupMainModels.swift
+++ b/Projects/Features/GroupFeature/Sources/GroupMain/GroupMainModels.swift
@@ -41,7 +41,7 @@ extension GroupMain {
       case .responded: return .blue
       case .confirmed: return .green
       case .all: return .pmindigo.n500
-      case .past: return Color(UIColor.systemGray)
+      case .past: return Color.pmgray.n500
       }
     }
 

--- a/Projects/Features/GroupFeature/Sources/GroupSettings/GroupSettingsAdditionalViews.swift
+++ b/Projects/Features/GroupFeature/Sources/GroupSettings/GroupSettingsAdditionalViews.swift
@@ -6,6 +6,8 @@ import ResourceKit
 import SwiftUI
 import UIKit
 
+private let kakaoYellowColor = Color(red: 254/255, green: 229/255, blue: 0/255)
+
 // MARK: - SheetsModifier
 
 struct SheetsModifier: ViewModifier {
@@ -534,7 +536,7 @@ struct InviteSheet: View {
         .font(.system(size: 16, weight: .semibold))
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
-        .background(Color(red: 254/255, green: 229/255, blue: 0/255))
+        .background(kakaoYellowColor)
         .foregroundStyle(.black)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
       }

--- a/Projects/Features/GroupFeature/Sources/Main/Views/Components/ScheduleCard.swift
+++ b/Projects/Features/GroupFeature/Sources/Main/Views/Components/ScheduleCard.swift
@@ -484,7 +484,7 @@ private struct ParticipantsAvatarView: View {
           .frame(width: 24, height: 24)
           .background(
             LinearGradient(
-              colors: [Color(red: 0.6, green: 0.6, blue: 0.65), Color(red: 0.45, green: 0.45, blue: 0.5)],
+              colors: [Color.pmgray.n400, Color.pmgray.n500],
               startPoint: .topLeading,
               endPoint: .bottomTrailing
             )

--- a/Projects/Features/GroupFeature/Tests/Sources/GroupFeatureTests.swift
+++ b/Projects/Features/GroupFeature/Tests/Sources/GroupFeatureTests.swift
@@ -279,6 +279,7 @@ struct GroupFeatureTests {
         RespondScheduleResult(scheduleId: "schedule-1", status: "accepted", isConfirmed: false, confirmedSchedule: nil)
       }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
     }
     store.exhaustivity = .off
 
@@ -303,6 +304,7 @@ struct GroupFeatureTests {
         RespondScheduleResult(scheduleId: "schedule-1", status: "accepted", isConfirmed: false, confirmedSchedule: nil)
       }
       $0.groupClient.fetchGroupSummaries = { [] }
+      $0.userDefaultsClient.boolForKey = { _ in false }
       $0.calendarSyncClient.removeSchedule = { _ in }
     }
     store.exhaustivity = .off

--- a/Projects/Features/NotificationCenterFeature/Sources/NotificationCenterView.swift
+++ b/Projects/Features/NotificationCenterFeature/Sources/NotificationCenterView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 extension NotificationCenter {
   public struct RootView: View {
-    private var store: StoreOf<Feature>
+    @Bindable private var store: StoreOf<Feature>
 
     public init(store: StoreOf<Feature>) {
       self.store = store

--- a/Projects/Features/PersonalFeature/Sources/Components/PersonalEventCard.swift
+++ b/Projects/Features/PersonalFeature/Sources/Components/PersonalEventCard.swift
@@ -158,7 +158,7 @@ public struct PersonalEventCard: View {
           Text(isReminderSent ? LocalizedStrings.Personal.reminderSent : reminderText(minutes))
             .font(.system(size: 13, weight: .medium))
         }
-        .foregroundStyle(isReminderSent ? .green : .secondary)
+        .foregroundStyle(isReminderSent ? Color.pmsuccess.n500 : Color.pmgray.n500)
       }
 
       Spacer()
@@ -224,10 +224,10 @@ private struct PersonalEventStatusBadge: View {
   }
 
   private var statusColor: Color {
-    if event.isOngoing { return .green }
-    if event.isPast { return Color(UIColor.systemGray) }
+    if event.isOngoing { return Color.pmsuccess.n500 }
+    if event.isPast { return Color.pmgray.n500 }
     let calendar = Calendar.current
-    if calendar.isDateInToday(event.startAt) { return .orange }
+    if calendar.isDateInToday(event.startAt) { return Color.pmwarning.n500 }
     return Color.pmindigo.n500
   }
 }

--- a/Projects/Features/PersonalFeature/Sources/PersonalFeature.swift
+++ b/Projects/Features/PersonalFeature/Sources/PersonalFeature.swift
@@ -37,8 +37,8 @@ extension PersonalMode {
 
     public var selectedColor: Color {
       switch self {
-      case .today: return .orange
-      case .future: return .blue
+      case .today: return Color.pmwarning.n500
+      case .future: return Color.pminfo.n500
       case .all: return .pmindigo.n500
       case .past: return Color.pmgray.n500
       }
@@ -83,6 +83,9 @@ extension PersonalMode {
 
       /// 일정 탭 기본 모드 (Settings에서 설정)
       @Shared(.appStorage(AppConstants.UserDefaults.defaultScheduleTabMode)) var defaultScheduleTabMode: String = "group"
+
+      /// 개인 캘린더 동기화 활성화 여부
+      @Shared(.appStorage(AppConstants.UserDefaults.personalCalendarSync)) var personalCalendarSyncEnabled: Bool = false
 
       @Presents var scheduleImport: ScheduleImport.Feature.State?
       @Presents var createEvent: CreatePersonalEvent.Feature.State?
@@ -197,6 +200,7 @@ extension PersonalMode {
     public enum Action: Sendable {
       case view(View)
       case `internal`(Internal)
+      case delegate(DelegateAction)
       case scheduleImport(PresentationAction<ScheduleImport.Feature.Action>)
       case alert(PresentationAction<Alert>)
       case createEvent(PresentationAction<CreatePersonalEvent.Feature.Action>)
@@ -209,6 +213,7 @@ extension PersonalMode {
         case confirmDelete
       }
 
+      @CasePathable
       public enum View: Sendable {
         case onAppear
         case refreshEvents
@@ -232,6 +237,7 @@ extension PersonalMode {
         case toastDismissed
       }
 
+      @CasePathable
       public enum Internal: Sendable {
         case subscribeToEvents
         case eventsUpdated([PersonalEventModel])
@@ -259,6 +265,11 @@ extension PersonalMode {
         case deeplinkExtractionSuccess(PersonalEventModel)
         case deeplinkExtractionFailed(originalText: String)
         case deeplinkExtractionImageFailed(imageData: Data)
+      }
+
+      @CasePathable
+      public enum DelegateAction: Sendable {
+        case switchToGroupMode
       }
     }
 
@@ -347,8 +358,7 @@ extension PersonalMode {
             return .none
 
           case .switchToGroupMode:
-            // RootTabFeature에서 처리
-            return .none
+            return .send(.delegate(.switchToGroupMode))
 
           case .openEventFromDeeplink(let eventId):
             return .run { send in
@@ -592,10 +602,8 @@ extension PersonalMode {
             return .none
 
           case .syncPersonalCalendar:
+            let enabled = state.personalCalendarSyncEnabled
             return .run(priority: .background) { [calendarSyncClient] _ in
-              let enabled = UserDefaults.standard.bool(
-                forKey: AppConstants.UserDefaults.personalCalendarSync
-              )
               let result = try? await calendarSyncClient.syncPersonalEvents(enabled)
               if let result {
                 AppLogger.calendar.info("📅 [Personal] syncCalendar 완료 - \(result.description)")
@@ -764,6 +772,9 @@ extension PersonalMode {
 
         case .alert:
           state.eventToDelete = nil
+          return .none
+
+        case .delegate:
           return .none
         }
       }

--- a/Projects/Features/PersonalFeature/Sources/PersonalView.swift
+++ b/Projects/Features/PersonalFeature/Sources/PersonalView.swift
@@ -264,7 +264,7 @@ extension PersonalMode {
         HStack(spacing: 8) {
           Image(systemName: "repeat")
             .font(.system(size: 14, weight: .semibold))
-            .foregroundStyle(.teal)
+            .foregroundStyle(Color.pminfo.n500)
 
           Text(LocalizedStrings.Personal.recurringEventsSummaryTitle)
             .font(.system(size: 16, weight: .bold))
@@ -272,10 +272,10 @@ extension PersonalMode {
 
           Text("\(count)")
             .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(.teal)
+            .foregroundStyle(Color.pminfo.n500)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(.teal.opacity(0.15))
+            .background(Color.pminfo.n500.opacity(0.15))
             .clipShape(Capsule())
 
           Spacer()
@@ -473,8 +473,8 @@ private struct RecurringEventCard: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .background(Color.teal.opacity(0.1))
-            .foregroundStyle(.teal)
+            .background(Color.pminfo.n500.opacity(0.1))
+            .foregroundStyle(Color.pminfo.n500)
             .clipShape(Capsule())
           }
 

--- a/Projects/Features/ProPlanFeature/Sources/PaywallView.swift
+++ b/Projects/Features/ProPlanFeature/Sources/PaywallView.swift
@@ -53,7 +53,9 @@ extension ProPlan {
             GeometryReader { geo in
               Color.clear
                 .onChange(of: geo.frame(in: .global).minY) { _, minY in
-                  let screenHeight = UIScreen.main.bounds.height
+                  let screenHeight = (UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .first?.screen.bounds.height) ?? 852
                   if minY < screenHeight - 100, !isPricingExpanded, !hasAutoExpanded {
                     hasAutoExpanded = true
                     withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {

--- a/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
+++ b/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
@@ -113,6 +113,7 @@ extension RootTab {
     @Dependency(\.analyticsClient) var analyticsClient
     @Dependency(\.subscriptionClient) var subscriptionClient
     @Dependency(\.appReviewClient) var appReviewClient
+    @Dependency(\.userDefaultsClient) var userDefaultsClient
 
     private enum CancelID: Hashable {
       case subscriptionStatus
@@ -181,14 +182,16 @@ extension RootTab {
       /// 일정 탭 기본 모드 (Settings에서 설정)
       @Shared(.appStorage(AppConstants.UserDefaults.defaultScheduleTabMode)) var defaultScheduleTabMode: String = "group"
 
+      /// 캘린더 기본 표시 모드 (Settings에서 설정)
+      @Shared(.appStorage(AppConstants.UserDefaults.defaultCalendarDisplayMode)) var defaultCalendarDisplayMode: String = "month"
+
       public init(currentUser: Shared<UserPrivateModel>) {
         self._currentUser = currentUser
         // @Shared appStorage에서 일정 탭 기본 모드 읽기
         self.scheduleMode = _defaultScheduleTabMode.wrappedValue == "own" ? .own : .group
         self.groupMain = GroupMain.Feature.State(currentUser: currentUser)
         self.home = Home.Feature.State(currentUser: currentUser)
-        let savedCalendarMode = UserDefaults.standard.string(forKey: AppConstants.UserDefaults.defaultCalendarDisplayMode)
-          .flatMap { CalendarDisplayMode(rawValue: $0) } ?? .month
+        let savedCalendarMode = CalendarDisplayMode(rawValue: _defaultCalendarDisplayMode.wrappedValue) ?? .month
         self.calendar = CalendarFeature.Feature.State(currentUser: currentUser, displayMode: savedCalendarMode)
         self.settings = Settings.Feature.State(currentUser: currentUser)
         self.personalMode = PersonalMode.Feature.State(currentUser: currentUser)
@@ -565,13 +568,13 @@ extension RootTab {
           case .pushToStartTokenReceived(let token):
             // Push to Start 토큰을 백엔드에 등록 (캐싱으로 중복 호출 방지)
             let cacheKey = CacheKeys.lastPushToStartToken
-            let lastToken = UserDefaults.standard.string(forKey: cacheKey)
+            let lastToken = userDefaultsClient.stringForKey(cacheKey)
             guard token != lastToken else { return .none }
 
-            return .run { _ in
+            return .run { [userDefaultsClient] _ in
               do {
                 try await notificationClient.saveLiveActivityPushToStartToken(token)
-                UserDefaults.standard.set(token, forKey: cacheKey)
+                userDefaultsClient.setString(token, cacheKey)
               } catch {
                 AppLogger.liveActivity.error("Push to Start 토큰 등록 실패: \(error.localizedDescription)")
               }
@@ -674,9 +677,7 @@ extension RootTab {
                 .filter { $0.notifications?.calendarSync ?? false }
                 .map { $0.id }
             )
-            let personalSyncEnabled = UserDefaults.standard.bool(
-              forKey: AppConstants.UserDefaults.personalCalendarSync
-            )
+            let personalSyncEnabled = userDefaultsClient.boolForKey(AppConstants.UserDefaults.personalCalendarSync)
             return .run(priority: .utility) { [calendarSyncClient] send in
               let allSucceeded = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
                 group.addTask {

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -362,13 +362,11 @@ struct RootTabFeatureTests {
 
   @Test("observePushToStartToken 구독 시 token 수신 후 저장")
   func observePushToStartToken_emitsAndSavesToken() async {
-    let original = UserDefaults.standard.string(forKey: cacheKey)
-    UserDefaults.standard.removeObject(forKey: cacheKey)
-    defer { restoreCacheKey(original) }
-
     let recorder = TokenRecorder()
 
     let store = makeStore(state: makeState(key: "observe-push-token")) {
+      $0.userDefaultsClient.stringForKey = { _ in nil }
+      $0.userDefaultsClient.setString = { _, _ in }
       $0.liveActivityClient.observePushToStartTokenUpdates = {
         AsyncStream { continuation in
           continuation.yield("token-1")
@@ -388,13 +386,10 @@ struct RootTabFeatureTests {
 
   @Test("pushToStartTokenReceived 중복 토큰이면 저장 생략")
   func pushToStartTokenReceived_duplicate_skipsSave() async {
-    let original = UserDefaults.standard.string(forKey: cacheKey)
-    UserDefaults.standard.set("same-token", forKey: cacheKey)
-    defer { restoreCacheKey(original) }
-
     let recorder = CallCounter()
 
     let store = makeStore(state: makeState(key: "push-token-duplicate")) {
+      $0.userDefaultsClient.stringForKey = { _ in "same-token" }
       $0.notificationClient.saveLiveActivityPushToStartToken = { _ in
         await recorder.increment()
       }
@@ -782,16 +777,6 @@ struct RootTabFeatureTests {
 }
 
 private extension RootTabFeatureTests {
-  var cacheKey: String { "lastPushToStartToken" }
-
-  func restoreCacheKey(_ original: String?) {
-    if let original {
-      UserDefaults.standard.set(original, forKey: cacheKey)
-    } else {
-      UserDefaults.standard.removeObject(forKey: cacheKey)
-    }
-  }
-
   actor CallCounter {
     private var count = 0
 
@@ -1046,5 +1031,9 @@ private extension RootTabFeatureTests {
 
     dependencies.appReviewClient.recordFirstLaunchIfNeeded = { }
     dependencies.appReviewClient.incrementSessionCount = { }
+
+    dependencies.userDefaultsClient.boolForKey = { _ in false }
+    dependencies.userDefaultsClient.stringForKey = { _ in nil }
+    dependencies.userDefaultsClient.setString = { _, _ in }
   }
 }

--- a/Projects/Features/SettingsFeature/Sources/CalendarSettings/CalendarSettingsFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/CalendarSettings/CalendarSettingsFeature.swift
@@ -40,7 +40,8 @@ extension CalendarSettings {
       public var isRequestingAccess: Bool
       public var groups: [UserGroupInfo]
       public var updatingGroupIds: Set<String>
-      public var personalCalendarSyncEnabled: Bool
+      @Shared(.appStorage(AppConstants.UserDefaults.personalCalendarSync))
+      public var personalCalendarSyncEnabled: Bool = false
       public var toastMessage: ToastMessage?
 
       public init() {
@@ -48,9 +49,6 @@ extension CalendarSettings {
         self.isRequestingAccess = false
         self.groups = []
         self.updatingGroupIds = []
-        self.personalCalendarSyncEnabled = UserDefaults.standard.bool(
-          forKey: AppConstants.UserDefaults.personalCalendarSync
-        )
         self.toastMessage = nil
       }
     }
@@ -132,8 +130,7 @@ extension CalendarSettings {
           }
 
         case .view(.personalCalendarSyncToggled(let enabled)):
-          state.personalCalendarSyncEnabled = enabled
-          UserDefaults.standard.set(enabled, forKey: AppConstants.UserDefaults.personalCalendarSync)
+          state.$personalCalendarSyncEnabled.withLock { $0 = enabled }
           analyticsClient.setCalendarSyncEnabled(
             personalEnabled: enabled,
             groups: state.groups

--- a/Projects/Features/SettingsFeature/Sources/NotificationSettings/NotificationSettingsFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/NotificationSettings/NotificationSettingsFeature.swift
@@ -757,8 +757,10 @@ private struct NotificationInfoPopover: View {
     .padding(.horizontal, 12)
     .offset(y: animateNotification ? 0 : -80)
     .clipped()
-    .task {
-      await loopAnimation()
+    .onAppear {
+      Task {
+        await loopAnimation()
+      }
     }
   }
 

--- a/Projects/Features/SettingsFeature/Sources/ProfileEditView.swift
+++ b/Projects/Features/SettingsFeature/Sources/ProfileEditView.swift
@@ -148,7 +148,7 @@ extension Settings {
               store.send(.view(.profileImageSelected(image.data)))
             }
           } catch {
-            store.send(.internal(.profileSaveFailed(SettingsError.imageLoadFailed.localizedDescription)))
+            store.send(.view(.imageLoadFailed(SettingsError.imageLoadFailed.localizedDescription)))
           }
         }
       }

--- a/Projects/Features/SettingsFeature/Sources/SettingsFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/SettingsFeature.swift
@@ -222,6 +222,8 @@ extension Settings {
       case toastDismissed
       /// 설명서 탭
       case guideTapped
+      /// 프로필 이미지 로드 실패
+      case imageLoadFailed(String)
     }
 
     /// 내부 비즈니스 로직 처리 결과 액션
@@ -475,6 +477,9 @@ extension Settings {
           case .guideTapped:
             state.path.append(.guide(Guide.Feature.State()))
             return .run { _ in await hapticFeedback.selection() }
+
+          case .imageLoadFailed(let errorMessage):
+            return .send(.internal(.profileSaveFailed(errorMessage)))
 
           }
 

--- a/Projects/Shared/Sources/UI/ButtonStyle.swift
+++ b/Projects/Shared/Sources/UI/ButtonStyle.swift
@@ -220,10 +220,11 @@ public extension View {
 
 // MARK: - Usage
 
+#if DEBUG
 struct ButtonExamples: View {
   @State private var showCreateGroup = false
   @State private var showJoinGroup = false
-  
+
   var body: some View {
     VStack(spacing: 12) {
       // ✅ Primary Button
@@ -238,7 +239,7 @@ struct ButtonExamples: View {
         .frame(height: 52)
       }
       .adaptivePrimaryButton()
-      
+
       // ✅ Secondary Button
       Button(action: { showJoinGroup = true }) {
         HStack(spacing: 8) {
@@ -251,7 +252,7 @@ struct ButtonExamples: View {
         .frame(height: 52)
       }
       .adaptiveSecondaryButton()
-      
+
       // ✅ Destructive Button
       Button(action: {}) {
         HStack(spacing: 8) {
@@ -268,6 +269,7 @@ struct ButtonExamples: View {
     .padding(.horizontal, 40)
   }
 }
+#endif
 
 #Preview("Adaptive Buttons") {
   ButtonExamples()

--- a/Projects/Shared/Sources/UI/Components/CategoryFilterBar.swift
+++ b/Projects/Shared/Sources/UI/Components/CategoryFilterBar.swift
@@ -94,7 +94,7 @@ public struct CategoryFilterBar<Item: CategoryFilterItem>: View {
       .padding(.vertical, 10)
       .background(
         Capsule()
-          .fill(isSelected ? item.selectedColor : Color(UIColor.systemGray5))
+          .fill(isSelected ? item.selectedColor : Color(.systemGray5))
       )
       .overlay(alignment: .topTrailing) {
         // Count badge (0보다 클 때만 표시)

--- a/Projects/Shared/Sources/UI/Components/GlassActionButton.swift
+++ b/Projects/Shared/Sources/UI/Components/GlassActionButton.swift
@@ -78,8 +78,8 @@ public struct GlassActionButton: View {
             if isPrimary {
               LinearGradient(
                 colors: [
-                  Color(red: 0.6, green: 0.4, blue: 0.9),
-                  Color(red: 0.5, green: 0.3, blue: 0.8)
+                  Color.pmpurple.n500,
+                  Color.pmpurple.n600
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
@@ -115,7 +115,7 @@ public struct GlassActionButton: View {
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(
           color: isPrimary
-          ? Color(red: 0.6, green: 0.4, blue: 0.9).opacity(0.3)
+          ? Color.pmpurple.n500.opacity(0.3)
           : Color.clear,
           radius: 12,
           y: 6

--- a/Projects/Shared/Sources/UI/Components/ImageDetailView.swift
+++ b/Projects/Shared/Sources/UI/Components/ImageDetailView.swift
@@ -100,7 +100,7 @@ public struct ImageDetailView: View {
     return Circle()
       .fill(
         LinearGradient(
-          colors: [Color(red: 0.3, green: 0.5, blue: 0.9), Color(red: 0.6, green: 0.4, blue: 0.8)],
+          colors: [Color.pmindigo.n400, Color.pmaurora.purple],
           startPoint: .topLeading,
           endPoint: .bottomTrailing
         )

--- a/Projects/Shared/Sources/UI/Components/LiveActivityInfoPopover.swift
+++ b/Projects/Shared/Sources/UI/Components/LiveActivityInfoPopover.swift
@@ -71,11 +71,11 @@ public struct LiveActivityInfoPopover: View {
       VStack(spacing: 4) {
         Text(LocalizedStrings.LiveSchedule.infoTitle)
           .font(.system(size: 17, weight: .bold))
-          .foregroundColor(.primary)
+          .foregroundStyle(.primary)
 
         Text(LocalizedStrings.LiveSchedule.infoSubtitle)
           .font(.system(size: 13))
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
           .multilineTextAlignment(.center)
       }
 
@@ -92,10 +92,10 @@ public struct LiveActivityInfoPopover: View {
       HStack(spacing: 6) {
         Image(systemName: "sparkles")
           .font(.system(size: 12))
-          .foregroundColor(.purple)
+          .foregroundStyle(.purple)
         Text(LocalizedStrings.LiveSchedule.autoStartDescription)
           .font(.system(size: 12))
-          .foregroundColor(.secondary)
+          .foregroundStyle(.secondary)
       }
       .padding(.top, 4)
     }

--- a/Projects/Shared/Sources/UI/Components/PhotoGalleryViewer.swift
+++ b/Projects/Shared/Sources/UI/Components/PhotoGalleryViewer.swift
@@ -102,10 +102,10 @@ private struct ZoomableImagePage: View {
         )
       } else if loadFailed {
         ZStack {
-          Color(UIColor.systemGray6).opacity(0.3)
+          Color(.systemGray6).opacity(0.3)
           Image(systemName: "exclamationmark.triangle")
             .font(.system(size: 40))
-            .foregroundStyle(Color(UIColor.systemGray3))
+            .foregroundStyle(Color(.systemGray3))
         }
         .frame(width: 200, height: 200)
         .clipShape(RoundedRectangle(cornerRadius: 16))

--- a/Projects/Shared/Sources/UI/Components/ProfileAvatarView.swift
+++ b/Projects/Shared/Sources/UI/Components/ProfileAvatarView.swift
@@ -68,7 +68,7 @@ public struct ProfileAvatarView: View {
     Circle()
       .fill(
         LinearGradient(
-          colors: [Color(red: 0.3, green: 0.5, blue: 0.9), Color(red: 0.6, green: 0.4, blue: 0.8)],
+          colors: [Color.pmindigo.n400, Color.pmaurora.purple],
           startPoint: .topLeading,
           endPoint: .bottomTrailing
         )

--- a/Projects/Shared/Sources/UI/SkeletonView.swift
+++ b/Projects/Shared/Sources/UI/SkeletonView.swift
@@ -20,7 +20,7 @@ public struct SkeletonView: View {
   public var body: some View {
     Rectangle()
       .fill(Color(.systemGray5))
-      .cornerRadius(cornerRadius)
+      .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
       .overlay(
         Rectangle()
           .fill(
@@ -37,7 +37,7 @@ public struct SkeletonView: View {
           .offset(x: isAnimating ? 400 : -400)
           .mask(
             Rectangle()
-              .cornerRadius(cornerRadius)
+              .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
           )
       )
       .onAppear {

--- a/infra/firebase/firestore.rules
+++ b/infra/firebase/firestore.rules
@@ -14,12 +14,56 @@ service cloud.firestore {
       //
       // 참고: Firestore rules에서 동적 키의 중첩 필드 검증은 제한적이므로
       // 클라이언트 측에서 해당 필드 직접 수정을 금지하고 API 사용을 강제함
-      allow read, write: if request.auth != null
-                        && request.auth.uid == userId;
+      allow read: if request.auth != null
+                 && request.auth.uid == userId;
 
-      match /{subcollection}/{docId} {
+      // 생성은 인증된 본인만 가능
+      allow create: if request.auth != null
+                   && request.auth.uid == userId;
+
+      // 수정은 민감 필드(groups, role) 직접 변경 차단
+      allow update: if request.auth != null
+                   && request.auth.uid == userId
+                   && request.resource.data.diff(resource.data)
+                        .affectedKeys()
+                        .hasOnly([
+                          'nickname', 'profile', 'devices',
+                          'metaData', 'fcmToken', 'lastActiveAt'
+                        ]);
+
+      // 삭제는 Admin SDK에서만 가능
+      allow delete: if false;
+
+      // auth 서브컬렉션: 인증 정보 (클라이언트 쓰기 불가)
+      match /auth/{docId} {
+        allow read: if request.auth != null
+                   && request.auth.uid == userId;
+        allow write: if false;
+      }
+
+      // settings 서브컬렉션: 사용자 설정 (본인만 읽기/쓰기)
+      match /settings/{docId} {
         allow read, write: if request.auth != null
                           && request.auth.uid == userId;
+      }
+
+      // personalEvents 서브컬렉션: 개인 일정 (본인만 읽기/쓰기)
+      match /personalEvents/{docId} {
+        allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+      }
+
+      // recurringEvents 서브컬렉션: 반복 일정 (본인만 읽기/쓰기)
+      match /recurringEvents/{docId} {
+        allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+      }
+
+      // cache 서브컬렉션: 서버 캐시 (클라이언트 쓰기 불가)
+      match /cache/{docId} {
+        allow read: if request.auth != null
+                   && request.auth.uid == userId;
+        allow write: if false;
       }
     }
 

--- a/infra/firebase/functions/src/functions/admin.ts
+++ b/infra/firebase/functions/src/functions/admin.ts
@@ -177,8 +177,8 @@ const RELEASE_CONTROL_GROUPS: Record<ReleaseControlKey, string> = {
   forceUpdateVersion: "version-control",
   recommendedVersion: "version-control",
   appStoreURL: "version-control",
-  privacyPolicyURL: "leagal-policies",
-  termsOfServiceURL: "leagal-policies",
+  privacyPolicyURL: "legal-policies",
+  termsOfServiceURL: "legal-policies",
   supportEmail: "customer-support",
   notionFAQDatabaseId: "customer-support",
 };

--- a/infra/firebase/functions/src/functions/groups.ts
+++ b/infra/firebase/functions/src/functions/groups.ts
@@ -734,7 +734,7 @@ export const deleteGroup = onCall<DeleteGroupRequest>(
  * 4. users/{userId}.groups[groupId].role 업데이트 (admin ↔ member)
  */
 export const transferGroupHost = onCall<TransferGroupHostRequest>(
-  {region: REGION, invoker: "public"},
+  {region: REGION},
   async (request): Promise<TransferGroupHostResponse> => {
     // 1. 인증 확인
     if (!request.auth) {
@@ -934,7 +934,7 @@ export const onGroupImageUpdated = onDocumentUpdated(
  * 5. 추방자가 참여한 미래 약속에서 투표 제거 + isConfirmed 재계산
  */
 export const expelMember = onCall<ExpelMemberRequest>(
-  {region: REGION, invoker: "public"},
+  {region: REGION},
   async (request): Promise<ExpelMemberResponse> => {
     // 1. 인증 확인
     if (!request.auth) {

--- a/infra/firebase/functions/src/functions/users.ts
+++ b/infra/firebase/functions/src/functions/users.ts
@@ -522,7 +522,7 @@ async function deleteCollectionByUserId(
  * 7. Firebase Auth 계정 삭제
  */
 export const deleteUser = onCall<DeleteUserRequest>(
-  {region: REGION, invoker: "public"},
+  {region: REGION},
   async (request): Promise<DeleteUserResponse> => {
     // 1. 인증 확인
     if (!request.auth) {
@@ -551,18 +551,22 @@ export const deleteUser = onCall<DeleteUserRequest>(
         throw new HttpsError("internal", "사용자 데이터를 읽을 수 없습니다");
       }
 
-      // 3. 그룹 호스트 여부 확인
-      const userGroups = userData.groups as Record<string, unknown> | undefined;
+      // 3. 그룹 호스트 여부 확인 (병렬 조회)
+      const userGroups = userData.groups as
+        Record<string, unknown> | undefined;
       const groupIds = userGroups ? Object.keys(userGroups) : [];
 
-      for (const groupId of groupIds) {
-        const groupDoc = await groupsCollection.doc(groupId).get();
+      const groupDocs = await Promise.all(
+        groupIds.map((id) => groupsCollection.doc(id).get()),
+      );
+      for (const groupDoc of groupDocs) {
         if (groupDoc.exists) {
           const groupData = groupDoc.data();
           if (groupData?.createdBy === userId) {
             throw new HttpsError(
               "failed-precondition",
-              "그룹 호스트는 탈퇴할 수 없습니다. 먼저 호스트를 양도하거나 그룹을 삭제해주세요."
+              "그룹 호스트는 탈퇴할 수 없습니다. " +
+              "먼저 호스트를 양도하거나 그룹을 삭제해주세요.",
             );
           }
         }
@@ -587,13 +591,16 @@ export const deleteUser = onCall<DeleteUserRequest>(
         console.log(`🗑️ ${hostPromises.size} host promises deleted`);
       }
 
-      // 5. 그룹 멤버십 정리 (memberIds에서 제거)
-      for (const groupId of groupIds) {
-        const groupRef = groupsCollection.doc(groupId);
-        await groupRef.update({
-          memberIds: FieldValue.arrayRemove(userId),
-          updatedAt: FieldValue.serverTimestamp(),
-        });
+      // 5. 그룹 멤버십 정리 (memberIds에서 제거) - 배치 처리
+      if (groupIds.length > 0) {
+        const membershipBatch = db.batch();
+        for (const groupId of groupIds) {
+          membershipBatch.update(groupsCollection.doc(groupId), {
+            memberIds: FieldValue.arrayRemove(userId),
+            updatedAt: FieldValue.serverTimestamp(),
+          });
+        }
+        await membershipBatch.commit();
       }
       console.log(`🗑️ Removed from ${groupIds.length} groups`);
 

--- a/infra/firebase/storage.rules
+++ b/infra/firebase/storage.rules
@@ -25,6 +25,9 @@ service firebase.storage {
     // 그룹 이미지
     // read/create: cross-service firestore.get() 불안정으로 인증만 확인
     // 실제 접근 제어는 download URL 토큰 + Functions 멤버십 검증으로 보장
+    // TODO: Firebase cross-service firestore.get() 안정화 후
+    //   create 규칙에 isGroupMember(groupId) 멤버십 검증 추가 필요.
+    //   현재는 인증된 사용자라면 누구나 create 가능하므로 보안 강화 필요.
     match /group_images/{groupId}/{fileName} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
@@ -39,6 +42,9 @@ service firebase.storage {
     // 약속 첨부 이미지
     // read/create: cross-service firestore.get() 불안정으로 인증만 확인
     // 실제 접근 제어는 download URL 토큰 + Functions 멤버십 검증으로 보장
+    // TODO: Firebase cross-service firestore.get() 안정화 후
+    //   create 규칙에 isGroupMember(groupId) 멤버십 검증 추가 필요.
+    //   현재는 인증된 사용자라면 누구나 create 가능하므로 보안 강화 필요.
     match /promise_images/{groupId}/{promiseId}/{fileName} {
       allow read: if request.auth != null;
       allow create: if request.auth != null


### PR DESCRIPTION
## Summary

전체 코드베이스 리뷰 후 Critical/Warning 이슈 일괄 수정 (38파일, 4개 레이어별 커밋)

### Infra 보안
- Firestore Rules: `users/{userId}` write 범위를 create/update/delete로 분리, 민감 필드(groups, role) 직접 수정 차단
- Firestore Rules: 서브컬렉션 와일드카드를 auth/settings/personalEvents/recurringEvents/cache별로 명시적 분리
- Functions: `deleteUser`, `transferGroupHost`, `expelMember`에서 `invoker: "public"` 제거
- Functions: `deleteUser` 내 N+1 순차 쿼리를 `Promise.all` + `batch` 처리로 개선
- admin.ts `"leagal-policies"` 오타 수정

### Clients 레이어
- `NotificationClient`, `AnalyticsClient`, `AppConfigClient`에 `@DependencyClient` 매크로 추가
- `ScheduleRemoteDataSource` 타임존 하드코딩(`Asia/Seoul`) → `TimeZone.current`
- `AuthClient` 빈 catch 블록에 widget token 에러 로깅 추가
- `UserProfileRemoteDataSource` `.prettyPrinted` 제거

### Shared 레이어
- 하드코딩 RGB 색상 → `Color.pm*` 교체 (GlassActionButton, ProfileAvatarView, ImageDetailView)
- deprecated `.cornerRadius` → `.clipShape(RoundedRectangle)` (SkeletonView)
- deprecated `.foregroundColor` → `.foregroundStyle` (LiveActivityInfoPopover)
- `Color(UIColor.*)` → `Color(.*)` (CategoryFilterBar, PhotoGalleryViewer)
- `ButtonExamples`를 `#if DEBUG`로 격리

### Features 레이어
- **TCA 패턴**: GroupMainFeature, PersonalFeature에 DelegateAction 추가 / AppEntryFeature, AuthFeature, PersonalFeature에 @CasePathable 보완 / NotificationCenterView에 @Bindable 추가
- **View 패턴**: `.task{}` → `.onAppear` 교체 (ArrivalSharingSection, NotificationSettings) / ProfileEditView `.internal` → ViewAction 경유
- **UserDefaults**: GroupMainFeature, AppEntryFeature, RootTabFeature, CalendarSettingsFeature, PersonalFeature에서 `UserDefaults.standard` 직접 접근 → `@Dependency(userDefaultsClient)` 또는 `@Shared(.appStorage)` 교체
- **보안**: AuthFeature `fatalError` → 안전한 폴백 / PaywallView `UIScreen.main.bounds` → `connectedScenes`
- **UI**: 하드코딩 색상 20곳+ → `Color.pm*` 교체 / CalendarRootView DateFormatter static 캐싱

## Test plan
- [x] Functions lint 통과 (error 0)
- [x] Clients 빌드+테스트 통과
- [x] Shared 빌드 통과
- [x] GroupFeature 빌드+테스트 (신규 실패 0, 기존 실패 2건)
- [x] HomeFeature 테스트 통과
- [x] PersonalFeature 테스트 통과
- [x] CalendarFeature 테스트 통과
- [x] SettingsFeature 테스트 통과
- [x] AppEntryFeature 빌드+테스트 (신규 실패 0, 기존 실패 5건)
- [x] CreateScheduleFeature 테스트 통과
- [ ] QA: Firestore Rules 변경 후 클라이언트 read/write 동작 확인
- [ ] QA: 일정 생성 시 타임존이 정상 반영되는지 확인

### 미수정 (별도 PR)
- AuthClient `@DependencyClient` (stored property 충돌)
- ScheduleRemoteDataSource `class→actor` (프로토콜 actor isolation 필요)
- Storage Rules 멤버십 검증 (`firestore.get()` 불안정)
- VoiceOver 접근성 (전체 앱 설계 필요)
- N+1 쿼리 배치화 (서버 API 추가 선행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)