### PR TITLE
fix: QA 워크플로 최신 릴리즈/슬랙 처리 개선

### DIFF
--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -54,6 +54,8 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 90
     needs: [resolve-ref]
+    env:
+      TUIST_ENV: stage
     outputs:
       qa_status: ${{ steps.curated.outputs.status }}
       app_build_status: ${{ steps.curated.outputs.app_build_status }}
@@ -120,8 +122,6 @@ jobs:
         run: tuist install
 
       - name: Generate Project
-        env:
-          TUIST_ENV: stage
         run: tuist generate --no-open
 
       - name: Run Curated iOS QA
@@ -417,85 +417,87 @@ jobs:
 
     steps:
       - name: Write Summary
+        env:
+          TARGET_REF: ${{ needs.resolve-ref.outputs.target_ref }}
+          IOS_RESULT: ${{ needs.ios-curated.result }}
+          IOS_APP_BUILD_STATUS: ${{ needs.ios-curated.outputs.app_build_status || 'n/a' }}
+          IOS_TESTED_MODULES: ${{ needs.ios-curated.outputs.tested_modules || 'n/a' }}
+          IOS_FAILED_MODULES: ${{ needs.ios-curated.outputs.failed_modules || 'none' }}
+          IOS_ERROR_SNIPPET: ${{ needs.ios-curated.outputs.error_snippet || 'No error snippet captured.' }}
+          ADMIN_RESULT: ${{ needs.admin-console.result }}
+          ADMIN_FAILURE_STEP: ${{ needs.admin-console.outputs.failure_step || 'unknown' }}
+          ADMIN_ERROR_SNIPPET: ${{ needs.admin-console.outputs.error_snippet || 'No error snippet captured.' }}
+          FUNCTIONS_RESULT: ${{ needs.functions.result }}
+          FUNCTIONS_FAILURE_STEP: ${{ needs.functions.outputs.failure_step || 'unknown' }}
+          FUNCTIONS_ERROR_SNIPPET: ${{ needs.functions.outputs.error_snippet || 'No error snippet captured.' }}
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          # QA Nightly Summary
+          {
+            printf '%s\n\n' '# QA Nightly Summary'
+            printf '%s\n' "- Target ref: \`$TARGET_REF\`"
+            printf '%s\n' '- Schedule: weekdays 18:00 KST / 09:00 UTC'
+            printf '%s\n' "- iOS curated status: \`$IOS_RESULT\`"
+            printf '%s\n' "- PromisoStage build: \`$IOS_APP_BUILD_STATUS\`"
+            printf '%s\n' "- Tested iOS modules: \`$IOS_TESTED_MODULES\`"
+            printf '%s\n' "- Failed iOS modules: \`$IOS_FAILED_MODULES\`"
+            printf '%s\n' "- Admin Console status: \`$ADMIN_RESULT\`"
+            printf '%s\n' "- Firebase Functions status: \`$FUNCTIONS_RESULT\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          - Target ref: \`${{ needs.resolve-ref.outputs.target_ref }}\`
-          - Schedule: weekdays 18:00 KST / 09:00 UTC
-          - iOS curated status: \`${{ needs.ios-curated.result }}\`
-          - PromisoStage build: \`${{ needs.ios-curated.outputs.app_build_status || 'n/a' }}\`
-          - Tested iOS modules: \`${{ needs.ios-curated.outputs.tested_modules || 'n/a' }}\`
-          - Failed iOS modules: \`${{ needs.ios-curated.outputs.failed_modules || 'none' }}\`
-          - Admin Console status: \`${{ needs.admin-console.result }}\`
-          - Firebase Functions status: \`${{ needs.functions.result }}\`
-          EOF
-
-          if [ "${{ needs.ios-curated.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## iOS Failure Highlights
-
-          ```text
-          ${{ needs.ios-curated.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$IOS_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## iOS Failure Highlights'
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$IOS_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "${{ needs.admin-console.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## Admin Console Failure Highlights
-
-          - Failed step: \`${{ needs.admin-console.outputs.failure_step || 'unknown' }}\`
-
-          ```text
-          ${{ needs.admin-console.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$ADMIN_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## Admin Console Failure Highlights'
+              printf '%s\n\n' "- Failed step: \`$ADMIN_FAILURE_STEP\`"
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$ADMIN_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "${{ needs.functions.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## Firebase Functions Failure Highlights
-
-          - Failed step: \`${{ needs.functions.outputs.failure_step || 'unknown' }}\`
-
-          ```text
-          ${{ needs.functions.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$FUNCTIONS_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## Firebase Functions Failure Highlights'
+              printf '%s\n\n' "- Failed step: \`$FUNCTIONS_FAILURE_STEP\`"
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$FUNCTIONS_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Notify Slack on Failure
         if: always() && (needs.ios-curated.result == 'failure' || needs.admin-console.result == 'failure' || needs.functions.result == 'failure')
         env:
           SLACK_QA_WEBHOOK_URL: ${{ secrets.SLACK_QA_WEBHOOK_URL }}
+          IOS_STATUS: ${{ needs.ios-curated.result }}
+          ADMIN_STATUS: ${{ needs.admin-console.result }}
+          FUNCTIONS_STATUS: ${{ needs.functions.result }}
+          IOS_ERROR_SNIPPET: ${{ needs.ios-curated.outputs.error_snippet }}
+          ADMIN_ERROR_SNIPPET: ${{ needs.admin-console.outputs.error_snippet }}
+          FUNCTIONS_ERROR_SNIPPET: ${{ needs.functions.outputs.error_snippet }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_REF: ${{ needs.resolve-ref.outputs.target_ref }}
         run: |
-          IOS_STATUS="${{ needs.ios-curated.result }}"
-          ADMIN_STATUS="${{ needs.admin-console.result }}"
-          FUNCTIONS_STATUS="${{ needs.functions.result }}"
-
           IOS_BADGE=$([ "$IOS_STATUS" = "success" ] && echo "pass" || echo "fail")
           ADMIN_BADGE=$([ "$ADMIN_STATUS" = "success" ] && echo "pass" || echo "fail")
           FUNCTIONS_BADGE=$([ "$FUNCTIONS_STATUS" = "success" ] && echo "pass" || echo "fail")
 
           ERROR_COMBINED=""
           if [ "$IOS_STATUS" = "failure" ]; then
-            SNIPPET="${{ needs.ios-curated.outputs.error_snippet }}"
+            SNIPPET="$IOS_ERROR_SNIPPET"
             if [ -n "$SNIPPET" ]; then
               ERROR_COMBINED="${ERROR_COMBINED}[iOS]\n${SNIPPET}\n"
             fi
           fi
           if [ "$ADMIN_STATUS" = "failure" ]; then
-            SNIPPET="${{ needs.admin-console.outputs.error_snippet }}"
+            SNIPPET="$ADMIN_ERROR_SNIPPET"
             if [ -n "$SNIPPET" ]; then
               ERROR_COMBINED="${ERROR_COMBINED}[Admin]\n${SNIPPET}\n"
             fi
           fi
           if [ "$FUNCTIONS_STATUS" = "failure" ]; then
-            SNIPPET="${{ needs.functions.outputs.error_snippet }}"
+            SNIPPET="$FUNCTIONS_ERROR_SNIPPET"
             if [ -n "$SNIPPET" ]; then
               ERROR_COMBINED="${ERROR_COMBINED}[Functions]\n${SNIPPET}\n"
             fi
@@ -505,11 +507,8 @@ jobs:
             ERROR_COMBINED="(에러 스니펫 없음)"
           fi
 
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          REF="${{ needs.resolve-ref.outputs.target_ref }}"
-
           PAYLOAD=$(jq -n \
-            --arg ref "$REF" \
+            --arg ref "$TARGET_REF" \
             --arg ios "$IOS_BADGE" \
             --arg admin "$ADMIN_BADGE" \
             --arg functions "$FUNCTIONS_BADGE" \

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -466,8 +466,8 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Notify Slack on Failure
-        if: always() && (needs.ios-curated.result == 'failure' || needs.admin-console.result == 'failure' || needs.functions.result == 'failure')
+      - name: Notify Slack
+        if: always()
         env:
           SLACK_QA_WEBHOOK_URL: ${{ secrets.SLACK_QA_WEBHOOK_URL }}
           IOS_STATUS: ${{ needs.ios-curated.result }}
@@ -483,68 +483,110 @@ jobs:
           ADMIN_BADGE=$([ "$ADMIN_STATUS" = "success" ] && echo "pass" || echo "fail")
           FUNCTIONS_BADGE=$([ "$FUNCTIONS_STATUS" = "success" ] && echo "pass" || echo "fail")
 
-          ERROR_COMBINED=""
-          if [ "$IOS_STATUS" = "failure" ]; then
-            SNIPPET="$IOS_ERROR_SNIPPET"
-            if [ -n "$SNIPPET" ]; then
-              ERROR_COMBINED="${ERROR_COMBINED}[iOS]\n${SNIPPET}\n"
-            fi
-          fi
-          if [ "$ADMIN_STATUS" = "failure" ]; then
-            SNIPPET="$ADMIN_ERROR_SNIPPET"
-            if [ -n "$SNIPPET" ]; then
-              ERROR_COMBINED="${ERROR_COMBINED}[Admin]\n${SNIPPET}\n"
-            fi
-          fi
-          if [ "$FUNCTIONS_STATUS" = "failure" ]; then
-            SNIPPET="$FUNCTIONS_ERROR_SNIPPET"
-            if [ -n "$SNIPPET" ]; then
-              ERROR_COMBINED="${ERROR_COMBINED}[Functions]\n${SNIPPET}\n"
-            fi
+          if [ "$IOS_STATUS" = "success" ] && [ "$ADMIN_STATUS" = "success" ] && [ "$FUNCTIONS_STATUS" = "success" ]; then
+            OVERALL_STATUS="success"
+          else
+            OVERALL_STATUS="failure"
           fi
 
-          if [ -z "$ERROR_COMBINED" ]; then
-            ERROR_COMBINED="(에러 스니펫 없음)"
-          fi
+          if [ "$OVERALL_STATUS" = "success" ]; then
+            PAYLOAD=$(jq -n \
+              --arg ref "$TARGET_REF" \
+              --arg ios "$IOS_BADGE" \
+              --arg admin "$ADMIN_BADGE" \
+              --arg functions "$FUNCTIONS_BADGE" \
+              --arg run_url "$RUN_URL" \
+              '{
+                blocks: [
+                  {
+                    type: "header",
+                    text: {type: "plain_text", text: "✅ QA Nightly 성공"}
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {type: "mrkdwn", text: ("*Ref:* `" + $ref + "`")},
+                      {type: "mrkdwn", text: ("*iOS:* " + $ios)},
+                      {type: "mrkdwn", text: ("*Admin:* " + $admin)},
+                      {type: "mrkdwn", text: ("*Functions:* " + $functions)}
+                    ]
+                  },
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {type: "plain_text", text: "Run 보기"},
+                        url: $run_url
+                      }
+                    ]
+                  }
+                ]
+              }')
+          else
+            ERROR_COMBINED=""
+            if [ "$IOS_STATUS" = "failure" ]; then
+              SNIPPET="$IOS_ERROR_SNIPPET"
+              if [ -n "$SNIPPET" ]; then
+                ERROR_COMBINED="${ERROR_COMBINED}[iOS]\n${SNIPPET}\n"
+              fi
+            fi
+            if [ "$ADMIN_STATUS" = "failure" ]; then
+              SNIPPET="$ADMIN_ERROR_SNIPPET"
+              if [ -n "$SNIPPET" ]; then
+                ERROR_COMBINED="${ERROR_COMBINED}[Admin]\n${SNIPPET}\n"
+              fi
+            fi
+            if [ "$FUNCTIONS_STATUS" = "failure" ]; then
+              SNIPPET="$FUNCTIONS_ERROR_SNIPPET"
+              if [ -n "$SNIPPET" ]; then
+                ERROR_COMBINED="${ERROR_COMBINED}[Functions]\n${SNIPPET}\n"
+              fi
+            fi
 
-          PAYLOAD=$(jq -n \
-            --arg ref "$TARGET_REF" \
-            --arg ios "$IOS_BADGE" \
-            --arg admin "$ADMIN_BADGE" \
-            --arg functions "$FUNCTIONS_BADGE" \
-            --arg error "$ERROR_COMBINED" \
-            --arg run_url "$RUN_URL" \
-            '{
-              blocks: [
-                {
-                  type: "header",
-                  text: {type: "plain_text", text: "🔴 QA Nightly 실패"}
-                },
-                {
-                  type: "section",
-                  fields: [
-                    {type: "mrkdwn", text: ("*Ref:* `" + $ref + "`")},
-                    {type: "mrkdwn", text: ("*iOS:* " + $ios)},
-                    {type: "mrkdwn", text: ("*Admin:* " + $admin)},
-                    {type: "mrkdwn", text: ("*Functions:* " + $functions)}
-                  ]
-                },
-                {
-                  type: "section",
-                  text: {type: "mrkdwn", text: ("*에러 요약*\n```" + $error + "```")}
-                },
-                {
-                  type: "actions",
-                  elements: [
-                    {
-                      type: "button",
-                      text: {type: "plain_text", text: "Run 보기"},
-                      url: $run_url
-                    }
-                  ]
-                }
-              ]
-            }')
+            if [ -z "$ERROR_COMBINED" ]; then
+              ERROR_COMBINED="(에러 스니펫 없음)"
+            fi
+
+            PAYLOAD=$(jq -n \
+              --arg ref "$TARGET_REF" \
+              --arg ios "$IOS_BADGE" \
+              --arg admin "$ADMIN_BADGE" \
+              --arg functions "$FUNCTIONS_BADGE" \
+              --arg error "$ERROR_COMBINED" \
+              --arg run_url "$RUN_URL" \
+              '{
+                blocks: [
+                  {
+                    type: "header",
+                    text: {type: "plain_text", text: "🔴 QA Nightly 실패"}
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {type: "mrkdwn", text: ("*Ref:* `" + $ref + "`")},
+                      {type: "mrkdwn", text: ("*iOS:* " + $ios)},
+                      {type: "mrkdwn", text: ("*Admin:* " + $admin)},
+                      {type: "mrkdwn", text: ("*Functions:* " + $functions)}
+                    ]
+                  },
+                  {
+                    type: "section",
+                    text: {type: "mrkdwn", text: ("*에러 요약*\n```" + $error + "```")}
+                  },
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {type: "plain_text", text: "Run 보기"},
+                        url: $run_url
+                      }
+                    ]
+                  }
+                ]
+              }')
+          fi
 
           curl -fsSL -X POST \
             -H "Content-Type: application/json" \

--- a/.github/workflows/qa-nightly.yml
+++ b/.github/workflows/qa-nightly.yml
@@ -14,17 +14,46 @@ on:
 permissions:
   contents: read
 
-env:
-  QA_TARGET_REF: ${{ github.event.inputs.ref || vars.QA_TARGET_REF || 'release/v1.3.1' }}
-
 concurrency:
   group: qa-nightly
   cancel-in-progress: false
 
 jobs:
+  resolve-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.ref.outputs.target_ref }}
+    steps:
+      - name: Resolve QA target ref
+        id: ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          INPUT_REF="${{ github.event.inputs.ref }}"
+          if [ -n "$INPUT_REF" ]; then
+            echo "target_ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
+            echo "Using manual ref: $INPUT_REF"
+            exit 0
+          fi
+
+          LATEST=$(gh api repos/${{ github.repository }}/branches \
+            --paginate -q '.[].name' \
+            | grep '^release/' \
+            | sort -V \
+            | tail -1)
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::No release/* branch found"
+            exit 1
+          fi
+
+          echo "target_ref=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Using latest release branch: $LATEST"
+
   ios-curated:
     runs-on: macos-15
     timeout-minutes: 90
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.curated.outputs.status }}
       app_build_status: ${{ steps.curated.outputs.app_build_status }}
@@ -36,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -91,6 +120,8 @@ jobs:
         run: tuist install
 
       - name: Generate Project
+        env:
+          TUIST_ENV: stage
         run: tuist generate --no-open
 
       - name: Run Curated iOS QA
@@ -202,6 +233,7 @@ jobs:
   admin-console:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.verify.outputs.status }}
       failure_step: ${{ steps.verify.outputs.failure_step }}
@@ -215,7 +247,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -284,6 +316,7 @@ jobs:
   functions:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.verify.outputs.status }}
       failure_step: ${{ steps.verify.outputs.failure_step }}
@@ -297,7 +330,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -377,6 +410,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - resolve-ref
       - ios-curated
       - admin-console
       - functions
@@ -387,7 +421,7 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           # QA Nightly Summary
 
-          - Target ref: \`${{ env.QA_TARGET_REF }}\`
+          - Target ref: \`${{ needs.resolve-ref.outputs.target_ref }}\`
           - Schedule: weekdays 18:00 KST / 09:00 UTC
           - iOS curated status: \`${{ needs.ios-curated.result }}\`
           - PromisoStage build: \`${{ needs.ios-curated.outputs.app_build_status || 'n/a' }}\`
@@ -472,7 +506,7 @@ jobs:
           fi
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          REF="${{ env.QA_TARGET_REF }}"
+          REF="${{ needs.resolve-ref.outputs.target_ref }}"
 
           PAYLOAD=$(jq -n \
             --arg ref "$REF" \

--- a/.github/workflows/qa-weekly.yml
+++ b/.github/workflows/qa-weekly.yml
@@ -14,17 +14,46 @@ on:
 permissions:
   contents: read
 
-env:
-  QA_TARGET_REF: ${{ github.event.inputs.ref || vars.QA_TARGET_REF || 'release/v1.3.1' }}
-
 concurrency:
   group: qa-weekly
   cancel-in-progress: false
 
 jobs:
+  resolve-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.ref.outputs.target_ref }}
+    steps:
+      - name: Resolve QA target ref
+        id: ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          INPUT_REF="${{ github.event.inputs.ref }}"
+          if [ -n "$INPUT_REF" ]; then
+            echo "target_ref=$INPUT_REF" >> "$GITHUB_OUTPUT"
+            echo "Using manual ref: $INPUT_REF"
+            exit 0
+          fi
+
+          LATEST=$(gh api repos/${{ github.repository }}/branches \
+            --paginate -q '.[].name' \
+            | grep '^release/' \
+            | sort -V \
+            | tail -1)
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::No release/* branch found"
+            exit 1
+          fi
+
+          echo "target_ref=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Using latest release branch: $LATEST"
+
   ios-full:
     runs-on: macos-15
     timeout-minutes: 150
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.full.outputs.status }}
       app_build_status: ${{ steps.full.outputs.app_build_status }}
@@ -35,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -90,6 +119,8 @@ jobs:
         run: tuist install
 
       - name: Generate Project
+        env:
+          TUIST_ENV: stage
         run: tuist generate --no-open
 
       - name: Run Full iOS QA
@@ -177,6 +208,7 @@ jobs:
   admin-console:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.verify.outputs.status }}
       failure_step: ${{ steps.verify.outputs.failure_step }}
@@ -190,7 +222,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -259,6 +291,7 @@ jobs:
   functions:
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    needs: [resolve-ref]
     outputs:
       qa_status: ${{ steps.verify.outputs.status }}
       failure_step: ${{ steps.verify.outputs.failure_step }}
@@ -272,7 +305,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.QA_TARGET_REF }}
+          ref: ${{ needs.resolve-ref.outputs.target_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -370,6 +403,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - resolve-ref
       - ios-full
       - admin-console
       - functions
@@ -380,7 +414,7 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           # QA Weekly Summary
 
-          - Target ref: \`${{ env.QA_TARGET_REF }}\`
+          - Target ref: \`${{ needs.resolve-ref.outputs.target_ref }}\`
           - Schedule: Monday 10:00 KST / 01:00 UTC
           - iOS full status: \`${{ needs.ios-full.result }}\`
           - PromisoStage build: \`${{ needs.ios-full.outputs.app_build_status || 'n/a' }}\`
@@ -460,7 +494,7 @@ jobs:
             "blocks": [
               {"type": "header", "text": {"type": "plain_text", "text": "✅ QA Weekly 성공"}},
               {"type": "section", "fields": [
-                {"type": "mrkdwn", "text": "*Ref:* \`${{ env.QA_TARGET_REF }}\`"},
+                {"type": "mrkdwn", "text": "*Ref:* \`${{ needs.resolve-ref.outputs.target_ref }}\`"},
                 {"type": "mrkdwn", "text": "*iOS:* ${IOS_EMOJI}"},
                 {"type": "mrkdwn", "text": "*Admin:* ${ADMIN_EMOJI}"},
                 {"type": "mrkdwn", "text": "*Functions:* ${FUNCTIONS_EMOJI}"}
@@ -500,7 +534,7 @@ jobs:
             "blocks": [
               {"type": "header", "text": {"type": "plain_text", "text": "🔴 QA Weekly 실패"}},
               {"type": "section", "fields": [
-                {"type": "mrkdwn", "text": "*Ref:* \`${{ env.QA_TARGET_REF }}\`"},
+                {"type": "mrkdwn", "text": "*Ref:* \`${{ needs.resolve-ref.outputs.target_ref }}\`"},
                 {"type": "mrkdwn", "text": "*iOS:* ${IOS_EMOJI}"},
                 {"type": "mrkdwn", "text": "*Admin:* ${ADMIN_EMOJI}"},
                 {"type": "mrkdwn", "text": "*Functions:* ${FUNCTIONS_EMOJI}"}

--- a/.github/workflows/qa-weekly.yml
+++ b/.github/workflows/qa-weekly.yml
@@ -54,6 +54,8 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 150
     needs: [resolve-ref]
+    env:
+      TUIST_ENV: stage
     outputs:
       qa_status: ${{ steps.full.outputs.status }}
       app_build_status: ${{ steps.full.outputs.app_build_status }}
@@ -119,8 +121,6 @@ jobs:
         run: tuist install
 
       - name: Generate Project
-        env:
-          TUIST_ENV: stage
         run: tuist generate --no-open
 
       - name: Run Full iOS QA
@@ -410,66 +410,66 @@ jobs:
 
     steps:
       - name: Write Summary
+        env:
+          TARGET_REF: ${{ needs.resolve-ref.outputs.target_ref }}
+          IOS_RESULT: ${{ needs.ios-full.result }}
+          IOS_APP_BUILD_STATUS: ${{ needs.ios-full.outputs.app_build_status || 'n/a' }}
+          IOS_TEST_STATUS: ${{ needs.ios-full.outputs.test_status || 'n/a' }}
+          IOS_ERROR_SNIPPET: ${{ needs.ios-full.outputs.error_snippet || 'No error snippet captured.' }}
+          ADMIN_RESULT: ${{ needs.admin-console.result }}
+          ADMIN_FAILURE_STEP: ${{ needs.admin-console.outputs.failure_step || 'unknown' }}
+          ADMIN_ERROR_SNIPPET: ${{ needs.admin-console.outputs.error_snippet || 'No error snippet captured.' }}
+          FUNCTIONS_RESULT: ${{ needs.functions.result }}
+          FUNCTIONS_FAILURE_STEP: ${{ needs.functions.outputs.failure_step || 'unknown' }}
+          FUNCTIONS_ERROR_SNIPPET: ${{ needs.functions.outputs.error_snippet || 'No error snippet captured.' }}
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          # QA Weekly Summary
+          {
+            printf '%s\n\n' '# QA Weekly Summary'
+            printf '%s\n' "- Target ref: \`$TARGET_REF\`"
+            printf '%s\n' '- Schedule: Monday 10:00 KST / 01:00 UTC'
+            printf '%s\n' "- iOS full status: \`$IOS_RESULT\`"
+            printf '%s\n' "- PromisoStage build: \`$IOS_APP_BUILD_STATUS\`"
+            printf '%s\n' "- Full test status: \`$IOS_TEST_STATUS\`"
+            printf '%s\n' "- Admin Console status: \`$ADMIN_RESULT\`"
+            printf '%s\n' "- Firebase Functions status: \`$FUNCTIONS_RESULT\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          - Target ref: \`${{ needs.resolve-ref.outputs.target_ref }}\`
-          - Schedule: Monday 10:00 KST / 01:00 UTC
-          - iOS full status: \`${{ needs.ios-full.result }}\`
-          - PromisoStage build: \`${{ needs.ios-full.outputs.app_build_status || 'n/a' }}\`
-          - Full test status: \`${{ needs.ios-full.outputs.test_status || 'n/a' }}\`
-          - Admin Console status: \`${{ needs.admin-console.result }}\`
-          - Firebase Functions status: \`${{ needs.functions.result }}\`
-          EOF
-
-          if [ "${{ needs.ios-full.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## iOS Failure Highlights
-
-          ```text
-          ${{ needs.ios-full.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$IOS_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## iOS Failure Highlights'
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$IOS_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "${{ needs.admin-console.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## Admin Console Failure Highlights
-
-          - Failed step: \`${{ needs.admin-console.outputs.failure_step || 'unknown' }}\`
-
-          ```text
-          ${{ needs.admin-console.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$ADMIN_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## Admin Console Failure Highlights'
+              printf '%s\n\n' "- Failed step: \`$ADMIN_FAILURE_STEP\`"
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$ADMIN_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "${{ needs.functions.result }}" != "success" ]; then
-            cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-
-          ## Firebase Functions Failure Highlights
-
-          - Failed step: \`${{ needs.functions.outputs.failure_step || 'unknown' }}\`
-
-          ```text
-          ${{ needs.functions.outputs.error_snippet || 'No error snippet captured.' }}
-          ```
-          EOF
+          if [ "$FUNCTIONS_RESULT" != "success" ]; then
+            {
+              printf '%s\n\n' '' '## Firebase Functions Failure Highlights'
+              printf '%s\n\n' "- Failed step: \`$FUNCTIONS_FAILURE_STEP\`"
+              printf '%s\n%s\n%s\n' "\`\`\`text" "$FUNCTIONS_ERROR_SNIPPET" "\`\`\`"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Notify Slack
         if: always()
         env:
           SLACK_QA_WEBHOOK_URL: ${{ secrets.SLACK_QA_WEBHOOK_URL }}
+          IOS_RESULT: ${{ needs.ios-full.result }}
+          ADMIN_RESULT: ${{ needs.admin-console.result }}
+          FUNCTIONS_RESULT: ${{ needs.functions.result }}
+          IOS_ERROR_SNIPPET: ${{ needs.ios-full.outputs.error_snippet }}
+          ADMIN_ERROR_SNIPPET: ${{ needs.admin-console.outputs.error_snippet }}
+          FUNCTIONS_ERROR_SNIPPET: ${{ needs.functions.outputs.error_snippet }}
+          TARGET_REF: ${{ needs.resolve-ref.outputs.target_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          IOS_RESULT="${{ needs.ios-full.result }}"
-          ADMIN_RESULT="${{ needs.admin-console.result }}"
-          FUNCTIONS_RESULT="${{ needs.functions.result }}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
           status_emoji() {
             case "$1" in
               success)  echo "✅" ;;
@@ -489,64 +489,94 @@ jobs:
           fi
 
           if [ "$OVERALL_STATUS" = "success" ]; then
-            PAYLOAD=$(cat <<JSON
-          {
-            "blocks": [
-              {"type": "header", "text": {"type": "plain_text", "text": "✅ QA Weekly 성공"}},
-              {"type": "section", "fields": [
-                {"type": "mrkdwn", "text": "*Ref:* \`${{ needs.resolve-ref.outputs.target_ref }}\`"},
-                {"type": "mrkdwn", "text": "*iOS:* ${IOS_EMOJI}"},
-                {"type": "mrkdwn", "text": "*Admin:* ${ADMIN_EMOJI}"},
-                {"type": "mrkdwn", "text": "*Functions:* ${FUNCTIONS_EMOJI}"}
-              ]},
-              {"type": "actions", "elements": [
-                {"type": "button", "text": {"type": "plain_text", "text": "Run 보기"}, "url": "${RUN_URL}"}
-              ]}
-            ]
-          }
-          JSON
-          )
+            PAYLOAD=$(jq -n \
+              --arg ref "$TARGET_REF" \
+              --arg ios "$IOS_EMOJI" \
+              --arg admin "$ADMIN_EMOJI" \
+              --arg functions "$FUNCTIONS_EMOJI" \
+              --arg run_url "$RUN_URL" \
+              '{
+                blocks: [
+                  {
+                    type: "header",
+                    text: {type: "plain_text", text: "✅ QA Weekly 성공"}
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {type: "mrkdwn", text: ("*Ref:* `" + $ref + "`")},
+                      {type: "mrkdwn", text: ("*iOS:* " + $ios)},
+                      {type: "mrkdwn", text: ("*Admin:* " + $admin)},
+                      {type: "mrkdwn", text: ("*Functions:* " + $functions)}
+                    ]
+                  },
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {type: "plain_text", text: "Run 보기"},
+                        url: $run_url
+                      }
+                    ]
+                  }
+                ]
+              }')
           else
-            IOS_SNIPPET="${{ needs.ios-full.outputs.error_snippet }}"
-            ADMIN_SNIPPET="${{ needs.admin-console.outputs.error_snippet }}"
-            FUNCTIONS_SNIPPET="${{ needs.functions.outputs.error_snippet }}"
-
             ERROR_SUMMARY=""
-            if [ "$IOS_RESULT" != "success" ] && [ -n "$IOS_SNIPPET" ]; then
-              ERROR_SUMMARY="[iOS]\n${IOS_SNIPPET}"
+            if [ "$IOS_RESULT" != "success" ] && [ -n "$IOS_ERROR_SNIPPET" ]; then
+              ERROR_SUMMARY="[iOS]\n${IOS_ERROR_SNIPPET}"
             fi
-            if [ "$ADMIN_RESULT" != "success" ] && [ -n "$ADMIN_SNIPPET" ]; then
+            if [ "$ADMIN_RESULT" != "success" ] && [ -n "$ADMIN_ERROR_SNIPPET" ]; then
               if [ -n "$ERROR_SUMMARY" ]; then ERROR_SUMMARY="${ERROR_SUMMARY}\n"; fi
-              ERROR_SUMMARY="${ERROR_SUMMARY}[Admin]\n${ADMIN_SNIPPET}"
+              ERROR_SUMMARY="${ERROR_SUMMARY}[Admin]\n${ADMIN_ERROR_SNIPPET}"
             fi
-            if [ "$FUNCTIONS_RESULT" != "success" ] && [ -n "$FUNCTIONS_SNIPPET" ]; then
+            if [ "$FUNCTIONS_RESULT" != "success" ] && [ -n "$FUNCTIONS_ERROR_SNIPPET" ]; then
               if [ -n "$ERROR_SUMMARY" ]; then ERROR_SUMMARY="${ERROR_SUMMARY}\n"; fi
-              ERROR_SUMMARY="${ERROR_SUMMARY}[Functions]\n${FUNCTIONS_SNIPPET}"
+              ERROR_SUMMARY="${ERROR_SUMMARY}[Functions]\n${FUNCTIONS_ERROR_SNIPPET}"
             fi
             if [ -z "$ERROR_SUMMARY" ]; then
               ERROR_SUMMARY="No error snippet captured."
             fi
 
-            ERROR_SUMMARY_ESCAPED=$(printf '%s' "$ERROR_SUMMARY" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" | sed 's/^"//;s/"$//')
-
-            PAYLOAD=$(cat <<JSON
-          {
-            "blocks": [
-              {"type": "header", "text": {"type": "plain_text", "text": "🔴 QA Weekly 실패"}},
-              {"type": "section", "fields": [
-                {"type": "mrkdwn", "text": "*Ref:* \`${{ needs.resolve-ref.outputs.target_ref }}\`"},
-                {"type": "mrkdwn", "text": "*iOS:* ${IOS_EMOJI}"},
-                {"type": "mrkdwn", "text": "*Admin:* ${ADMIN_EMOJI}"},
-                {"type": "mrkdwn", "text": "*Functions:* ${FUNCTIONS_EMOJI}"}
-              ]},
-              {"type": "section", "text": {"type": "mrkdwn", "text": "*에러 요약*\n\`\`\`${ERROR_SUMMARY_ESCAPED}\`\`\`"}},
-              {"type": "actions", "elements": [
-                {"type": "button", "text": {"type": "plain_text", "text": "Run 보기"}, "url": "${RUN_URL}"}
-              ]}
-            ]
-          }
-          JSON
-          )
+            PAYLOAD=$(jq -n \
+              --arg ref "$TARGET_REF" \
+              --arg ios "$IOS_EMOJI" \
+              --arg admin "$ADMIN_EMOJI" \
+              --arg functions "$FUNCTIONS_EMOJI" \
+              --arg error "$ERROR_SUMMARY" \
+              --arg run_url "$RUN_URL" \
+              '{
+                blocks: [
+                  {
+                    type: "header",
+                    text: {type: "plain_text", text: "🔴 QA Weekly 실패"}
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      {type: "mrkdwn", text: ("*Ref:* `" + $ref + "`")},
+                      {type: "mrkdwn", text: ("*iOS:* " + $ios)},
+                      {type: "mrkdwn", text: ("*Admin:* " + $admin)},
+                      {type: "mrkdwn", text: ("*Functions:* " + $functions)}
+                    ]
+                  },
+                  {
+                    type: "section",
+                    text: {type: "mrkdwn", text: ("*에러 요약*\n```" + $error + "```")}
+                  },
+                  {
+                    type: "actions",
+                    elements: [
+                      {
+                        type: "button",
+                        text: {type: "plain_text", text: "Run 보기"},
+                        url: $run_url
+                      }
+                    ]
+                  }
+                ]
+              }')
           fi
 
           curl -fsSL -X POST \


### PR DESCRIPTION
## Summary
- nightly/weekly QA가 최신 `release/*` 브랜치를 자동 선택하도록 수정했습니다.
- iOS QA job에 `TUIST_ENV=stage`를 일관되게 적용해 `PromisoStage` 빌드 실패를 수정했습니다.
- nightly/weekly summary/slack 스크립트의 shell 해석 문제를 제거했고, nightly는 성공 시에도 Slack 알림을 보내도록 확장했습니다.

## 변경 유형
- [ ] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [x] chore: 설정, 빌드 등 기타 변경
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정

## 변경 파일
- `.github/workflows/qa-nightly.yml`
- `.github/workflows/qa-weekly.yml`

## 스크린샷 (UI 변경 시)

## Test plan
- [x] 빌드 성공 확인
- [x] 기존 기능 정상 동작 확인

## 관련 이슈
-