### PR TITLE
fix: 앱 평가하기 버튼이 App Store 페이지를 바로 열도록 수정

### DIFF
--- a/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
@@ -26,7 +26,6 @@ extension Support {
 
     @Dependency(\.hapticFeedback) private var hapticFeedback
     @Dependency(\.openURL) private var openURL
-    @Dependency(\.appReviewClient) private var appReviewClient
 
     public init() {}
 
@@ -106,7 +105,7 @@ extension Support {
         case .view(.rateAppTapped):
           return .run { _ in
             await hapticFeedback.selection()
-            await appReviewClient.requestReviewIfEligible()
+            await openURL(AppConstants.appStoreURL)
           }
 
         case .view(.toastDismissed):

--- a/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
@@ -105,7 +105,7 @@ extension Support {
         case .view(.rateAppTapped):
           return .run { _ in
             await hapticFeedback.selection()
-            await openURL(AppConstants.appStoreURL)
+            await openURL(AppConstants.App.appStoreURL)
           }
 
         case .view(.toastDismissed):


### PR DESCRIPTION
## Summary

- 설정 > 지원 > 앱 평가하기 버튼이 적격성 조건(첫 실행 7일, 세션 3회, 쿨다운 90일) 때문에 아무 반응 없이 무시되던 문제를 수정
- `SKStoreReviewController.requestReview` 대신 App Store URL을 직접 열어 사용자가 탭하면 항상 App Store로 이동하도록 변경

## 변경 유형

- [x] fix: 버그 수정

## 변경 파일

- `Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift`

## Test plan

- [ ] 빌드 성공 확인
- [ ] 설정 > 지원 > 앱 평가하기 탭 시 App Store 페이지로 이동 확인
- [ ] 기존 기능 정상 동작 확인