### PR TITLE
fix: App Store 업데이트 링크 변경

### DIFF
--- a/Projects/Clients/Sources/Clients/AppConfigClient.swift
+++ b/Projects/Clients/Sources/Clients/AppConfigClient.swift
@@ -118,7 +118,7 @@ extension AppConfigClient: DependencyKey {
     let defaults: [String: NSObject] = [
       RemoteConfigKeys.forceUpdateVersion: "0.0.0" as NSString,
       RemoteConfigKeys.recommendedVersion: "0.0.0" as NSString,
-      RemoteConfigKeys.appStoreURL: "https://apps.apple.com/app/id1625074042" as NSString,
+      RemoteConfigKeys.appStoreURL: "https://apps.apple.com/kr/app/id6757733720" as NSString,
       RemoteConfigKeys.privacyPolicyURL: "https://www.notion.so/3029e497067580beb0aaf485a0dd4a02" as NSString,
       RemoteConfigKeys.termsOfServiceURL: "https://www.notion.so/3029e4970675802ab781e282bb92d63b" as NSString,
       RemoteConfigKeys.supportEmail: "kswen0203@icloud.com" as NSString,

--- a/Projects/Clients/Sources/Clients/AppConfigClient.swift
+++ b/Projects/Clients/Sources/Clients/AppConfigClient.swift
@@ -118,7 +118,7 @@ extension AppConfigClient: DependencyKey {
     let defaults: [String: NSObject] = [
       RemoteConfigKeys.forceUpdateVersion: "0.0.0" as NSString,
       RemoteConfigKeys.recommendedVersion: "0.0.0" as NSString,
-      RemoteConfigKeys.appStoreURL: "https://apps.apple.com/kr/app/id6757733720" as NSString,
+      RemoteConfigKeys.appStoreURL: AppConfigModel.defaultConfig.appStoreURL as NSString,
       RemoteConfigKeys.privacyPolicyURL: "https://www.notion.so/3029e497067580beb0aaf485a0dd4a02" as NSString,
       RemoteConfigKeys.termsOfServiceURL: "https://www.notion.so/3029e4970675802ab781e282bb92d63b" as NSString,
       RemoteConfigKeys.supportEmail: "kswen0203@icloud.com" as NSString,

--- a/Projects/Shared/Sources/Constants/AppConstants.swift
+++ b/Projects/Shared/Sources/Constants/AppConstants.swift
@@ -55,7 +55,7 @@ public struct AppConfigModel: Equatable, Sendable {
   public static let defaultConfig = AppConfigModel(
     forceUpdateVersion: "0.0.0",
     recommendedVersion: "0.0.0",
-    appStoreURL: "https://apps.apple.com/app/id1625074042",
+    appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
     privacyPolicyURL: "https://www.notion.so/3029e497067580beb0aaf485a0dd4a02",
     termsOfServiceURL: "https://www.notion.so/3029e4970675802ab781e282bb92d63b",
     supportEmail: "kswen0203@icloud.com",

--- a/infra/firebase/functions/test/admin.test.ts
+++ b/infra/firebase/functions/test/admin.test.ts
@@ -124,7 +124,7 @@ describe("admin functions", () => {
               defaultValue: {value: "1.1.0"},
             },
             appStoreURL: {
-              defaultValue: {value: "https://apps.apple.com/app/id1625074042"},
+              defaultValue: {value: "https://apps.apple.com/kr/app/id6757733720"},
             },
           },
         },
@@ -1639,7 +1639,7 @@ describe("admin functions", () => {
       controls: expect.objectContaining({
         forceUpdateVersion: "1.0.0",
         recommendedVersion: "1.1.0",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://example.com/privacy",
         termsOfServiceURL: "https://example.com/terms",
         supportEmail: "support@promiso.app",
@@ -1697,7 +1697,7 @@ describe("admin functions", () => {
       data: {
         forceUpdateVersion: "1.0.0",
         recommendedVersion: "1.1.0",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://promiso.app/privacy",
         termsOfServiceURL: "https://promiso.app/terms",
         supportEmail: "help@promiso.app",
@@ -1753,7 +1753,7 @@ describe("admin functions", () => {
       data: {
         forceUpdateVersion: "1.2.0",
         recommendedVersion: "1.1.0",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://example.com/privacy",
         termsOfServiceURL: "https://example.com/terms",
         supportEmail: "support@promiso.app",
@@ -1782,7 +1782,7 @@ describe("admin functions", () => {
       data: {
         forceUpdateVersion: "1.2",
         recommendedVersion: "1.2.1",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://promiso.app/privacy",
         termsOfServiceURL: "https://promiso.app/terms",
         supportEmail: "support@promiso.app",
@@ -1810,7 +1810,7 @@ describe("admin functions", () => {
       data: {
         forceUpdateVersion: "1.2.0",
         recommendedVersion: "1.2.1",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://promiso.app/privacy",
         termsOfServiceURL: "https://promiso.app/terms",
         supportEmail: "support@promiso.app",
@@ -1829,7 +1829,7 @@ describe("admin functions", () => {
       controls: expect.objectContaining({
         forceUpdateVersion: "1.2.0",
         recommendedVersion: "1.2.1",
-        appStoreURL: "https://apps.apple.com/app/id1625074042",
+        appStoreURL: "https://apps.apple.com/kr/app/id6757733720",
         privacyPolicyURL: "https://promiso.app/privacy",
         termsOfServiceURL: "https://promiso.app/terms",
         supportEmail: "support@promiso.app",

--- a/infra/firebase/remoteconfig-console.json
+++ b/infra/firebase/remoteconfig-console.json
@@ -16,7 +16,7 @@
     },
     "appStoreURL": {
       "defaultValue": {
-        "value": "https://apps.apple.com/app/id1625074042"
+        "value": "https://apps.apple.com/kr/app/id6757733720"
       },
       "description": "App Store 앱 링크 (업데이트 버튼 클릭 시 이동)",
       "valueType": "STRING"

--- a/infra/firebase/remoteconfig.template.json
+++ b/infra/firebase/remoteconfig.template.json
@@ -17,7 +17,7 @@
     },
     "appStoreURL": {
       "defaultValue": {
-        "value": "https://apps.apple.com/app/id1625074042"
+        "value": "https://apps.apple.com/kr/app/id6757733720"
       },
       "description": "App Store 앱 링크 (업데이트 버튼 클릭 시 이동)",
       "valueType": "STRING"


### PR DESCRIPTION
## Summary
- 업데이트 유도 링크의 기본값을 실제 Promiso App Store URL(`https://apps.apple.com/kr/app/id6757733720`)로 변경
- iOS 앱 코드(AppConstants, AppConfigClient), Remote Config 템플릿, Functions 테스트 일괄 반영

## Test plan
- [ ] 권장 업데이트 알림에서 업데이트 버튼 탭 시 올바른 App Store 페이지로 이동하는지 확인
- [ ] 강제 업데이트 알림에서도 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)