### PR TITLE
feat: DescriptionBlockRenderer에 전화/주소/링크 자동 감지 버튼 추가

### DIFF
--- a/Projects/Shared/Sources/UI/Components/DescriptionBlockRenderer.swift
+++ b/Projects/Shared/Sources/UI/Components/DescriptionBlockRenderer.swift
@@ -77,15 +77,18 @@ public struct DescriptionBlockRenderer: View {
         return DetectedItem(id: key, kind: .url, value: key, url: url)
       case .phoneNumber:
         guard let phone = match.phoneNumber else { return nil }
-        guard seen.insert(phone).inserted else { return nil }
         let cleaned = phone.replacingOccurrences(of: "[^0-9+]", with: "", options: .regularExpression)
-        return DetectedItem(id: phone, kind: .phone, value: phone, url: URL(string: "tel:\(cleaned)"))
+        guard seen.insert(cleaned).inserted else { return nil }
+        return DetectedItem(id: cleaned, kind: .phone, value: phone, url: URL(string: "tel:\(cleaned)"))
       case .address:
         guard let range = Range(match.range, in: text) else { return nil }
         let address = String(text[range])
         guard seen.insert(address).inserted else { return nil }
-        let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? address
-        return DetectedItem(id: address, kind: .address, value: address, url: URL(string: "\(AppConstants.ExternalURLs.kakaoMapSearchBase)\(encoded)"))
+        guard let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(string: "\(AppConstants.ExternalURLs.kakaoMapSearchBase)\(encoded)") else {
+          return nil
+        }
+        return DetectedItem(id: address, kind: .address, value: address, url: url)
       default:
         return nil
       }

--- a/Projects/Shared/Sources/UI/Components/DescriptionBlockRenderer.swift
+++ b/Projects/Shared/Sources/UI/Components/DescriptionBlockRenderer.swift
@@ -1,11 +1,38 @@
 import SwiftUI
 
+// MARK: - Detected Item
+
+private struct DetectedItem: Identifiable {
+  enum Kind { case url, phone, address }
+  let id: String
+  let kind: Kind
+  let value: String
+  let url: URL?
+
+  var emoji: String {
+    switch kind {
+    case .url: "🔗"
+    case .phone: "📞"
+    case .address: "📍"
+    }
+  }
+
+  var label: String {
+    switch kind {
+    case .url: url?.host ?? value
+    case .phone: value
+    case .address: value
+    }
+  }
+}
+
 // MARK: - Description Block Renderer
 
 public struct DescriptionBlockRenderer: View {
   private let blocks: [DescriptionBlock]
   @Binding private var isExpanded: Bool
   private let onChecklistToggle: ((String, String) -> Void)?
+  @Environment(\.openURL) private var openURL
 
   public init(
     blocks: [DescriptionBlock],
@@ -15,6 +42,54 @@ public struct DescriptionBlockRenderer: View {
     self.blocks = blocks
     self._isExpanded = isExpanded
     self.onChecklistToggle = onChecklistToggle
+  }
+
+  // MARK: - Data Detection
+
+  private static let dataDetector: NSDataDetector? = {
+    let types: NSTextCheckingResult.CheckingType = [.link, .phoneNumber, .address]
+    return try? NSDataDetector(types: types.rawValue)
+  }()
+
+  private var allText: String {
+    blocks.flatMap { block -> [String] in
+      switch block.content {
+      case .text(let text): [text]
+      case .checklist(let items): items.map(\.text)
+      case .bulletList(let items): items
+      }
+    }
+    .joined(separator: "\n")
+  }
+
+  private var detectedItems: [DetectedItem] {
+    guard let detector = Self.dataDetector else { return [] }
+    let text = allText
+    let range = NSRange(text.startIndex..., in: text)
+    let matches = detector.matches(in: text, options: [], range: range)
+    var seen = Set<String>()
+    return matches.compactMap { match -> DetectedItem? in
+      switch match.resultType {
+      case .link:
+        guard let url = match.url else { return nil }
+        let key = url.absoluteString
+        guard seen.insert(key).inserted else { return nil }
+        return DetectedItem(id: key, kind: .url, value: key, url: url)
+      case .phoneNumber:
+        guard let phone = match.phoneNumber else { return nil }
+        guard seen.insert(phone).inserted else { return nil }
+        let cleaned = phone.replacingOccurrences(of: "[^0-9+]", with: "", options: .regularExpression)
+        return DetectedItem(id: phone, kind: .phone, value: phone, url: URL(string: "tel:\(cleaned)"))
+      case .address:
+        guard let range = Range(match.range, in: text) else { return nil }
+        let address = String(text[range])
+        guard seen.insert(address).inserted else { return nil }
+        let encoded = address.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? address
+        return DetectedItem(id: address, kind: .address, value: address, url: URL(string: "\(AppConstants.ExternalURLs.kakaoMapSearchBase)\(encoded)"))
+      default:
+        return nil
+      }
+    }
   }
 
   // 더보기 표시 여부: 블록이 많거나 체크리스트 항목이 5개 초과이거나 텍스트 블록이 많으면 표시
@@ -36,6 +111,37 @@ public struct DescriptionBlockRenderer: View {
     VStack(alignment: .leading, spacing: 8) {
       ForEach(visibleBlocks) { block in
         blockView(block)
+      }
+
+      let items = detectedItems
+      if !items.isEmpty {
+        let layout = items.count > 1
+          ? AnyLayout(VStackLayout(alignment: .leading, spacing: 6))
+          : AnyLayout(HStackLayout(spacing: 6))
+        layout {
+          ForEach(items) { item in
+            if let url = item.url {
+              Button {
+                openURL(url)
+              } label: {
+                HStack(spacing: 3) {
+                  Text(item.emoji)
+                    .font(.system(size: 11))
+                  Text(item.label)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.ultraThinMaterial, in: Capsule())
+                .overlay(Capsule().strokeBorder(.secondary.opacity(0.2), lineWidth: 0.5))
+                .contentShape(Capsule())
+              }
+              .buttonStyle(.plain)
+            }
+          }
+        }
+        .padding(.top, 4)
       }
 
       if needsExpansion {
@@ -157,7 +263,7 @@ public struct DescriptionBlockRenderer: View {
   @Previewable @State var isExpanded = false
   return DescriptionBlockRenderer(
     blocks: [
-      DescriptionBlock(content: .text("강남역 2번 출구에서 만나요.")),
+      DescriptionBlock(content: .text("강남역 2번 출구에서 만나요. 문의: 010-1234-5678")),
       DescriptionBlock(content: .checklist([
         ChecklistItem(text: "지갑", isChecked: true),
         ChecklistItem(text: "신분증"),
@@ -166,7 +272,7 @@ public struct DescriptionBlockRenderer: View {
         ChecklistItem(text: "간식"),
         ChecklistItem(text: "물병")
       ])),
-      DescriptionBlock(content: .bulletList(["장소: 강남역", "시간: 오후 6시"]))
+      DescriptionBlock(content: .bulletList(["장소: 강남역", "시간: 오후 6시", "참고: https://naver.com"]))
     ],
     isExpanded: $isExpanded
   )
@@ -177,7 +283,7 @@ public struct DescriptionBlockRenderer: View {
   @Previewable @State var isExpanded = true
   return DescriptionBlockRenderer(
     blocks: [
-      DescriptionBlock(content: .text("강남역 2번 출구에서 만나요. 늦으면 연락주세요.")),
+      DescriptionBlock(content: .text("강남역 2번 출구에서 만나요. 늦으면 연락주세요. 문의: 010-1234-5678, https://naver.com")),
       DescriptionBlock(content: .checklist([
         ChecklistItem(text: "지갑", isChecked: true),
         ChecklistItem(text: "신분증"),


### PR DESCRIPTION
## Summary

- 블록 에디터(`descriptionBlocks`) 방식의 일정 설명에서도 전화번호, 주소, 웹링크를 NSDataDetector로 자동 감지하여 Capsule 버튼으로 표시
- 텍스트 블록뿐 아니라 체크리스트, 불릿리스트 항목의 텍스트에서도 감지
- 기존 레거시 `ScheduleDetailExpandableText`와 동일한 UI/UX 패턴 적용

## 변경 유형

- [x] feat: 새로운 기능
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] chore: 설정, 빌드 등 기타 변경
- [ ] docs: 문서 수정
- [ ] test: 테스트 추가/수정

## 변경 파일

- `Projects/Shared/Sources/UI/Components/DescriptionBlockRenderer.swift`

## 스크린샷 (UI 변경 시)

N/A (기존 `ScheduleDetailExpandableText`와 동일한 Capsule 버튼 UI)

## Test plan

- [x] 빌드 성공 확인
- [ ] 기존 기능 정상 동작 확인
- [ ] descriptionBlocks에 전화번호 포함 텍스트 → 📞 버튼 표시 확인
- [ ] descriptionBlocks에 URL 포함 텍스트 → 🔗 버튼 표시 확인
- [ ] descriptionBlocks에 주소 포함 텍스트 → 📍 버튼 표시 확인
- [ ] 체크리스트/불릿리스트 항목 내 링크도 감지되는지 확인
- [ ] 레거시 description(plain text) 일정의 기존 감지 버튼 정상 동작 확인

## 관련 이슈