### PR TITLE
fix: 나침반 모드에서 마커가 지도와 함께 회전하는 버그 수정

### DIFF
--- a/Projects/Features/SharedFeature/Sources/ScheduleDetail/LocationDetailMapView.swift
+++ b/Projects/Features/SharedFeature/Sources/ScheduleDetail/LocationDetailMapView.swift
@@ -323,9 +323,7 @@ public struct KakaoInteractiveMapView: UIViewRepresentable {
           guard normalizedDiff > 1 else { continue }
           await MainActor.run {
             self.lastHeading = heading
-            // POI 부채꼴 회전 (radian)
-            self.userLocationPoi?.rotateAt(heading * .pi / 180.0, duration: 200)
-            // 카메라 회전 (moveCamera = 즉시, 애니메이션 큐잉 없음)
+            // 카메라 회전만 적용 — POI 아이콘은 화면 기준 고정이므로 별도 회전 불필요
             if let mapView = self.mapController?.getView("mapview") as? KakaoMap,
                let coord = self.lastUserCoordinate {
               self.updateHeadingCamera(mapView: mapView, coordinate: coord, headingDegrees: heading)


### PR DESCRIPTION
## Summary

- 나침반(followWithHeading) 모드에서 카메라 회전과 POI `rotateAt`이 동시에 적용되어 마커가 화면에서 고정되지 않고 지도와 함께 회전하는 버그 수정
- POI 아이콘은 화면 좌표계 기준으로 고정되므로 `rotateAt` 호출을 제거하고 카메라 회전만 적용

## 변경 유형

- [x] fix: 버그 수정

## 변경 파일

- `Projects/Features/SharedFeature/Sources/ScheduleDetail/LocationDetailMapView.swift`

## Test plan

- [ ] 빌드 성공 확인
- [ ] 나침반 모드(followWithHeading)에서 마커가 화면 상단을 향해 고정되는지 확인
- [ ] 마커는 고정되고 지도만 회전하는지 확인
- [ ] follow 모드, none 모드 전환 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)