### PR TITLE
chore: 버전 1.3.2 변경 및 앱 평가하기 인앱 리뷰로 전환

### DIFF
--- a/Projects/Clients/Sources/Clients/AppReviewClient.swift
+++ b/Projects/Clients/Sources/Clients/AppReviewClient.swift
@@ -15,6 +15,8 @@ public struct AppReviewClient: Sendable {
   public var incrementSessionCount: @Sendable () -> Void
   /// 리뷰 요청 적격 여부 판단 (적격이면 요청일 기록 후 리뷰 요청)
   public var requestReviewIfEligible: @Sendable () async -> Void
+  /// 자격 조건 없이 바로 인앱 리뷰 요청 (설정 > 앱 평가하기용)
+  public var requestReview: @Sendable () async -> Void
 }
 
 // MARK: - Test / Preview
@@ -71,6 +73,15 @@ extension AppReviewClient: DependencyKey {
         // 적격 → 요청일 기록 + 리뷰 요청
         defaults.set(now.timeIntervalSince1970, forKey: AppConstants.UserDefaults.lastReviewRequestDate)
 
+        await MainActor.run {
+          guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
+            return
+          }
+          SKStoreReviewController.requestReview(in: scene)
+        }
+      },
+      requestReview: {
         await MainActor.run {
           guard let scene = UIApplication.shared.connectedScenes
             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {

--- a/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
+++ b/Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift
@@ -26,6 +26,7 @@ extension Support {
 
     @Dependency(\.hapticFeedback) private var hapticFeedback
     @Dependency(\.openURL) private var openURL
+    @Dependency(\.appReviewClient) private var appReviewClient
 
     public init() {}
 
@@ -105,7 +106,7 @@ extension Support {
         case .view(.rateAppTapped):
           return .run { _ in
             await hapticFeedback.selection()
-            await openURL(AppConstants.App.appStoreURL)
+            await appReviewClient.requestReview()
           }
 
         case .view(.toastDismissed):
@@ -309,10 +310,6 @@ extension Support {
                   .foregroundStyle(Color.pmtext.primary)
 
                 Spacer()
-
-                Image(systemName: "arrow.up.forward")
-                  .font(.caption)
-                  .foregroundStyle(Color.pmgray.n400)
               }
               .padding(.horizontal, 16)
               .padding(.vertical, 14)

--- a/Tuist/ProjectDescriptionHelpers/AppConfig.swift
+++ b/Tuist/ProjectDescriptionHelpers/AppConfig.swift
@@ -16,7 +16,7 @@ public enum AppConfig {
   public static let defaultRegions = ["en", "ko"]
   
   public static let teamId = "BAC795627G"
-  public static let marketingNumber: String = "1.3.1"
+  public static let marketingNumber: String = "1.3.2"
   
   public static func buildVersion(for environment: String = "dev") -> String {
     let now = Date()


### PR DESCRIPTION
## Summary

- 마케팅 버전을 1.3.1 → 1.3.2로 변경
- 설정 > 지원 > 앱 평가하기 버튼을 App Store URL 열기에서 인앱 리뷰(`SKStoreReviewController`)로 전환
- `AppReviewClient`에 자격 조건 없이 바로 리뷰를 요청하는 `requestReview` 메서드 추가

## 변경 유형

- [x] feat: 새로운 기능
- [x] chore: 설정, 빌드 등 기타 변경

## 변경 파일

- `Tuist/ProjectDescriptionHelpers/AppConfig.swift` — 버전 1.3.2 변경
- `Projects/Clients/Sources/Clients/AppReviewClient.swift` — `requestReview` 메서드 추가
- `Projects/Features/SettingsFeature/Sources/Support/SupportFeature.swift` — 인앱 리뷰 호출로 변경, 외부 링크 아이콘 제거

## Test plan

- [ ] 빌드 성공 확인
- [ ] 실기기에서 설정 > 지원 > 앱 평가하기 탭 시 인앱 리뷰 팝업 표시 확인
- [ ] 기존 자동 트리거(일정 생성 완료 시) 정상 동작 확인