### PR TITLE
fix: ButtonExamples Preview #if DEBUG 누락으로 릴리스 빌드 실패 수정

### DIFF
--- a/Projects/Shared/Sources/UI/ButtonStyle.swift
+++ b/Projects/Shared/Sources/UI/ButtonStyle.swift
@@ -271,9 +271,11 @@ struct ButtonExamples: View {
 }
 #endif
 
+#if DEBUG
 #Preview("Adaptive Buttons") {
   ButtonExamples()
 }
+#endif
 
 #Preview("Interactive Styles") {
   VStack(spacing: 24) {


### PR DESCRIPTION
## Summary

- `ButtonExamples`는 `#if DEBUG` 안에 정의되어 있지만, 이를 참조하는 `#Preview("Adaptive Buttons")`가 `#if DEBUG` 밖에 있어 릴리스(Archive) 빌드 시 `cannot find 'ButtonExamples' in scope` 에러 발생
- `#Preview` 블록을 `#if DEBUG`로 감싸서 릴리스 빌드 수정

## 변경 유형

- [x] fix: 버그 수정

## 변경 파일

- `Projects/Shared/Sources/UI/ButtonStyle.swift`

## 스크린샷 (UI 변경 시)

N/A

## Test plan

- [x] 빌드 성공 확인
- [x] 기존 기능 정상 동작 확인

## 관련 이슈

Deploy iOS GitHub Actions 빌드 실패 (#23712263608)