### PR TITLE
feat: 일정 도메인 Rust 마이그레이션 + 블로그 #4

### DIFF
--- a/.ai/POSTGRES_SCHEMA.md
+++ b/.ai/POSTGRES_SCHEMA.md
@@ -354,9 +354,9 @@ CREATE TABLE recurring_schedules (
 | uq_groups_invite_code | groups | invite_code | UNIQUE | 초대 코드 충돌 방지 |
 | uq_group_members_single_admin | group_members | group_id WHERE role='admin' | PARTIAL UNIQUE | 그룹당 admin 1명 강제 |
 | idx_group_members_user_joined_at | group_members | (user_id, joined_at DESC) | INDEX | 내 그룹 목록 최신순 조회 최적화 |
-| idx_schedules_group_start | schedules | (group_id, start_at) WHERE type='group' | PARTIAL INDEX | 그룹일정 시간순 조회 |
-| idx_schedules_personal_start | schedules | (user_id, start_at) WHERE type='personal' | PARTIAL INDEX | 개인일정 시간순 조회 |
-| idx_schedules_confirmed | schedules | (start_at) WHERE type='group' AND is_confirmed | PARTIAL INDEX | 캘린더 동기화 (확정 미래 일정) |
+| idx_schedules_group_start | schedules | (group_id, start_at) WHERE schedule_type='group' | PARTIAL INDEX | 그룹일정 시간순 조회 |
+| idx_schedules_personal_start | schedules | (user_id, start_at) WHERE schedule_type='personal' | PARTIAL INDEX | 개인일정 시간순 조회 |
+| idx_schedules_confirmed | schedules | (start_at) WHERE schedule_type='group' AND is_confirmed | PARTIAL INDEX | 캘린더 동기화 (확정 미래 일정) |
 | idx_schedule_votes_user | schedule_votes | (user_id, status) | INDEX | 유저의 accepted 일정 조회 |
 | idx_recurring_user | recurring_schedules | (user_id) | INDEX | 유저의 반복일정 조회 |
 

--- a/.ai/POSTGRES_SCHEMA.md
+++ b/.ai/POSTGRES_SCHEMA.md
@@ -132,6 +132,220 @@ CREATE TABLE group_members (
 | `groups/{id}.memberIds` 배열 | 동일, group_members로 흡수 |
 | 알림 설정 (`groups` Map의 notifications) | JSONB 없이 명시적 컬럼으로 관리 |
 
+## schedules
+
+그룹일정과 개인일정을 단일 테이블로 통합. `schedule_type`으로 구분하고, CHECK 제약으로 타입별 필드 정합성 보장.
+
+```sql
+CREATE TYPE schedule_type AS ENUM ('group', 'personal');
+
+CREATE TABLE schedules (
+  id                            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_type                 schedule_type NOT NULL,
+  user_id                       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                                -- personal: 소유자, group: 호스트
+
+  -- 공통 필드
+  title                         TEXT NOT NULL,
+  emoji                         TEXT,
+  description                   TEXT,
+  description_blocks            JSONB,
+  start_at                      TIMESTAMPTZ NOT NULL,
+  end_at                        TIMESTAMPTZ,
+  location_name                 TEXT,
+  location_address              TEXT,
+  location_latitude             DOUBLE PRECISION,
+  location_longitude            DOUBLE PRECISION,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- 그룹일정 전용 (personal이면 NULL)
+  group_id                      UUID REFERENCES groups(id) ON DELETE CASCADE,
+  minimum_participants          SMALLINT,
+  is_confirmed                  BOOLEAN,
+  vote_deadline                 TIMESTAMPTZ,
+  tracking_start_minutes_before SMALLINT,
+  image_urls                    TEXT[],
+
+  -- 개인일정 전용 (group이면 NULL)
+  reminder_minutes_before       SMALLINT,
+
+  -- 제약 조건
+  CONSTRAINT chk_title_not_empty   CHECK (char_length(trim(title)) > 0),
+  CONSTRAINT chk_title_max_len     CHECK (char_length(title) <= 30),
+  CONSTRAINT chk_desc_max_len      CHECK (description IS NULL OR char_length(description) <= 500),
+  CONSTRAINT chk_end_after_start   CHECK (end_at IS NULL OR end_at > start_at),
+  CONSTRAINT chk_min_participants  CHECK (minimum_participants IS NULL OR minimum_participants >= 1),
+  CONSTRAINT chk_desc_blocks_max   CHECK (description_blocks IS NULL OR jsonb_array_length(description_blocks) <= 20),
+  CONSTRAINT chk_image_urls_max    CHECK (image_urls IS NULL OR array_length(image_urls, 1) <= 3),
+
+  -- 타입별 필드 정합성
+  CONSTRAINT chk_schedule_type_fields CHECK (
+    (schedule_type = 'group'
+      AND group_id IS NOT NULL
+      AND minimum_participants IS NOT NULL
+      AND is_confirmed IS NOT NULL
+      AND vote_deadline IS NOT NULL)
+    OR
+    (schedule_type = 'personal'
+      AND group_id IS NULL
+      AND minimum_participants IS NULL
+      AND is_confirmed IS NULL
+      AND vote_deadline IS NULL
+      AND tracking_start_minutes_before IS NULL
+      AND image_urls IS NULL)
+  )
+);
+```
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | UUID | PK | 자동 생성 UUID |
+| schedule_type | schedule_type | NOT NULL | `group` / `personal` |
+| user_id | TEXT | NOT NULL, FK → users.id CASCADE | personal: 소유자, group: 호스트 |
+| title | TEXT | NOT NULL, 1~30자 | 일정 제목 |
+| emoji | TEXT | nullable | 대표 이모지 |
+| description | TEXT | nullable, 최대 500자 | 일정 설명 |
+| description_blocks | JSONB | nullable, 최대 20개 | 구조화된 설명 블록 |
+| start_at | TIMESTAMPTZ | NOT NULL | 시작 시각 |
+| end_at | TIMESTAMPTZ | nullable, > start_at | 종료 시각 |
+| location_* | TEXT/DOUBLE | nullable | 장소 정보 (name, address, lat, lng) |
+| group_id | UUID | FK → groups.id CASCADE | 그룹일정 전용 |
+| minimum_participants | SMALLINT | >= 1 | 최소 확정 인원 |
+| is_confirmed | BOOLEAN | | accepted >= minimum_participants |
+| vote_deadline | TIMESTAMPTZ | | 투표 마감 시각 (기본 = start_at) |
+| tracking_start_minutes_before | SMALLINT | nullable | LiveActivity 시작 시간 (분) |
+| image_urls | TEXT[] | 최대 3개 | 첨부 이미지 URL |
+| reminder_minutes_before | SMALLINT | nullable | 개인일정 알림 (분) |
+
+| Firestore 원본 | 비고 |
+|---------------|------|
+| `promises/{id}` | schedule_type = 'group'으로 통합 |
+| `users/{uid}/personalEvents/{id}` | schedule_type = 'personal'로 통합 |
+| `votes` Map (accepted/declined) | schedule_votes 테이블로 분리 |
+| `isConfirmed` 비정규화 | 유지 (캘린더 쿼리 성능) |
+| `votes.until` | vote_deadline 컬럼으로 매핑 |
+| `liveActivitySchedule`, `badgesCleared` | 제거 (#7, #5에서 별도 마이그레이션) |
+| `users/{uid}/scheduleSlots/{date}` | 제거 (SQL 인덱스 쿼리로 대체, 비정규화 불필요) |
+
+## schedule_votes
+
+그룹일정 투표. pending 상태는 group_members에서 schedule_votes를 빼서 계산.
+
+```sql
+CREATE TYPE vote_status AS ENUM ('accepted', 'declined');
+
+CREATE TABLE schedule_votes (
+  schedule_id  UUID NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  status       vote_status NOT NULL,
+  responded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (schedule_id, user_id)
+);
+```
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| schedule_id | UUID | PK, FK → schedules.id CASCADE | 일정 ID |
+| user_id | TEXT | PK, FK → users.id CASCADE | 투표자 ID |
+| status | vote_status | NOT NULL | `accepted` / `declined` |
+| responded_at | TIMESTAMPTZ | NOT NULL, default NOW() | 응답 시각 |
+
+> pending = group_members - schedule_votes (저장하지 않고 계산)
+
+| Firestore 원본 | 비고 |
+|---------------|------|
+| `promises/{id}.votes.accepted[]` | status = 'accepted' |
+| `promises/{id}.votes.declined[]` | status = 'declined' |
+| pending (memberIds - accepted - declined) | 테이블 부재로 계산 |
+
+## recurring_schedules
+
+반복일정 규칙. 인스턴스는 저장하지 않고 클라이언트/서버에서 규칙 기반 계산.
+
+```sql
+CREATE TYPE recurrence_frequency AS ENUM ('daily', 'weekly', 'monthly');
+
+CREATE TABLE recurring_schedules (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title                   TEXT NOT NULL,
+  emoji                   TEXT,
+  description             TEXT,
+  start_time_hour         SMALLINT NOT NULL,
+  start_time_minute       SMALLINT NOT NULL,
+  end_time_hour           SMALLINT,
+  end_time_minute         SMALLINT,
+  location_name           TEXT,
+  location_address        TEXT,
+  location_latitude       DOUBLE PRECISION,
+  location_longitude      DOUBLE PRECISION,
+  reminder_minutes_before SMALLINT,
+  frequency               recurrence_frequency NOT NULL,
+  days_of_week            SMALLINT[],        -- weekly: [1=일..7=토]
+  day_of_month            SMALLINT,           -- monthly: 1~31
+  series_start_date       DATE NOT NULL,
+  series_end_date         DATE,               -- NULL = 무기한
+  excluded_dates          DATE[],
+  overrides               JSONB,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT chk_rec_title_not_empty    CHECK (char_length(trim(title)) > 0),
+  CONSTRAINT chk_start_hour             CHECK (start_time_hour BETWEEN 0 AND 23),
+  CONSTRAINT chk_start_minute           CHECK (start_time_minute BETWEEN 0 AND 59),
+  CONSTRAINT chk_end_hour               CHECK (end_time_hour IS NULL OR end_time_hour BETWEEN 0 AND 23),
+  CONSTRAINT chk_end_minute             CHECK (end_time_minute IS NULL OR end_time_minute BETWEEN 0 AND 59),
+  CONSTRAINT chk_end_time_pair          CHECK (
+    (end_time_hour IS NULL AND end_time_minute IS NULL) OR
+    (end_time_hour IS NOT NULL AND end_time_minute IS NOT NULL)
+  ),
+  -- frequency별 상호배타 필드 정합성
+  CONSTRAINT chk_recurrence_fields CHECK (
+    (frequency = 'daily'
+      AND days_of_week IS NULL
+      AND day_of_month IS NULL)
+    OR
+    (frequency = 'weekly'
+      AND days_of_week IS NOT NULL
+      AND array_length(days_of_week, 1) > 0
+      AND day_of_month IS NULL)
+    OR
+    (frequency = 'monthly'
+      AND days_of_week IS NULL
+      AND day_of_month IS NOT NULL
+      AND day_of_month BETWEEN 1 AND 31)
+  ),
+  CONSTRAINT chk_series_end_after_start CHECK (series_end_date IS NULL OR series_end_date >= series_start_date)
+);
+```
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|------|------|------|------|
+| id | UUID | PK | 자동 생성 UUID |
+| user_id | TEXT | FK → users.id CASCADE | 소유자 |
+| title | TEXT | NOT NULL, 비어있지 않음 | 일정 제목 |
+| emoji | TEXT | nullable | 대표 이모지 |
+| description | TEXT | nullable | 일정 설명 |
+| start_time_hour/minute | SMALLINT | NOT NULL, 0~23/0~59 | 시작 시각 |
+| end_time_hour/minute | SMALLINT | nullable, 쌍으로 존재 | 종료 시각 |
+| location_* | TEXT/DOUBLE | nullable | 장소 정보 |
+| reminder_minutes_before | SMALLINT | nullable | 알림 시간 (분) |
+| frequency | recurrence_frequency | NOT NULL | `daily` / `weekly` / `monthly` |
+| days_of_week | SMALLINT[] | weekly 필수 | 반복 요일 [1=일..7=토] |
+| day_of_month | SMALLINT | monthly 필수, 1~31 | 반복 일자 |
+| series_start_date | DATE | NOT NULL | 반복 시작일 |
+| series_end_date | DATE | nullable, >= start | 반복 종료일 (NULL=무기한) |
+| excluded_dates | DATE[] | nullable | 취소된 날짜 |
+| overrides | JSONB | nullable | 날짜별 수정 `{"2026-03-24": {...}}` |
+
+| Firestore 원본 | 비고 |
+|---------------|------|
+| `users/{uid}/recurringEvents/{id}` | 별도 테이블 유지 (규칙 vs 인스턴스) |
+| `recurrence` Map | frequency + days_of_week + day_of_month로 분해 |
+| `startTime`/`endTime` Map | hour/minute 개별 컬럼으로 분해 |
+
 ## 인덱스
 
 | 인덱스명 | 대상 테이블 | 컬럼 | 종류 | 목적 |
@@ -140,11 +354,38 @@ CREATE TABLE group_members (
 | uq_groups_invite_code | groups | invite_code | UNIQUE | 초대 코드 충돌 방지 |
 | uq_group_members_single_admin | group_members | group_id WHERE role='admin' | PARTIAL UNIQUE | 그룹당 admin 1명 강제 |
 | idx_group_members_user_joined_at | group_members | (user_id, joined_at DESC) | INDEX | 내 그룹 목록 최신순 조회 최적화 |
+| idx_schedules_group_start | schedules | (group_id, start_at) WHERE type='group' | PARTIAL INDEX | 그룹일정 시간순 조회 |
+| idx_schedules_personal_start | schedules | (user_id, start_at) WHERE type='personal' | PARTIAL INDEX | 개인일정 시간순 조회 |
+| idx_schedules_confirmed | schedules | (start_at) WHERE type='group' AND is_confirmed | PARTIAL INDEX | 캘린더 동기화 (확정 미래 일정) |
+| idx_schedule_votes_user | schedule_votes | (user_id, status) | INDEX | 유저의 accepted 일정 조회 |
+| idx_recurring_user | recurring_schedules | (user_id) | INDEX | 유저의 반복일정 조회 |
 
 ## 타입
 
 | 타입명 | 종류 | 값 | 설명 |
 |--------|------|-----|------|
 | group_member_role | ENUM | 'admin', 'member' | 그룹 내 역할 |
+| schedule_type | ENUM | 'group', 'personal' | 일정 구분 |
+| vote_status | ENUM | 'accepted', 'declined' | 투표 상태 (pending = 부재) |
+| recurrence_frequency | ENUM | 'daily', 'weekly', 'monthly' | 반복 주기 |
 
-*마지막 업데이트: 2026-04-05*
+## scheduleSlots 제거 근거
+
+Firestore에서는 `users/{uid}/scheduleSlots/{YYYY-MM-DD}` 비정규화 컬렉션으로 O(1) 충돌 체크를 구현하고, 7개 트리거로 동기화를 유지했다.
+
+PostgreSQL에서는 SQL 인덱스 쿼리로 동일한 성능을 달성할 수 있어 비정규화가 불필요하다:
+
+```sql
+-- 충돌 감지: 유저의 모든 일정을 시간 범위로 조회
+SELECT s.id, s.title, s.start_at, s.end_at FROM schedules s
+JOIN schedule_votes sv ON sv.schedule_id = s.id
+WHERE sv.user_id = $1 AND sv.status = 'accepted'
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL)
+UNION ALL
+SELECT s.id, s.title, s.start_at, s.end_at FROM schedules s
+WHERE s.schedule_type = 'personal' AND s.user_id = $1
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL);
+-- + recurring_schedules는 앱 레벨에서 규칙 기반 확장
+```
+
+*마지막 업데이트: 2026-04-06*

--- a/.ai/REST_API.md
+++ b/.ai/REST_API.md
@@ -270,4 +270,385 @@ GET /api/v1/groups/{id}, POST /api/v1/groups/join 응답의 `data` 필드:
 }
 ```
 
-*마지막 업데이트: 2026-04-05*
+## Schedules (인증 필요)
+
+### POST /api/v1/schedules
+
+- 설명: 일정 생성 (그룹일정 또는 개인일정)
+- 인증: 필수. 그룹일정: 그룹 멤버만. 개인일정: 누구나
+- 요청:
+  ```json
+  {
+    "schedule_type": "group",
+    "group_id": "uuid (group 필수)",
+    "title": "영화 관람",
+    "emoji": "🎬",
+    "description": "마블 신작",
+    "description_blocks": [{"type": "text", "content": "..."}],
+    "start_at": "ISO8601",
+    "end_at": "ISO8601 (optional)",
+    "location": {
+      "name": "CGV 강남",
+      "address": "서울 강남구 ... (optional)",
+      "latitude": 37.501 ,
+      "longitude": 127.026
+    },
+    "minimum_participants": 2,
+    "tracking_start_minutes_before": 30,
+    "image_urls": ["https://..."],
+    "reminder_minutes_before": 60
+  }
+  ```
+  - `group_id`: group 타입 필수, personal 타입이면 생략
+  - `minimum_participants`: group 타입 필수 (>= 1), personal이면 생략
+  - `tracking_start_minutes_before`, `image_urls`: group 전용
+  - `reminder_minutes_before`: personal 전용
+  - `location`: 선택. 있으면 `name` 필수
+  - `description_blocks`: 최대 20개
+  - `image_urls`: 최대 3개
+- 응답 201:
+  ```json
+  {
+    "data": {
+      "schedule_id": "uuid",
+      "title": "영화 관람",
+      "group_id": "uuid",
+      "start_at": "ISO8601",
+      "is_confirmed": false
+    }
+  }
+  ```
+  - 그룹일정: 호스트 자동 accepted (P16), is_confirmed 자동 계산 (P21)
+  - vote_deadline = start_at (P19)
+- 에러: 400 (유효성), 403 (그룹 멤버 아님), 404 (그룹 없음)
+
+### GET /api/v1/schedules/{id}
+
+- 설명: 일정 상세 조회
+- 인증: 필수. 그룹일정: 그룹 멤버만. 개인일정: 소유자만
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "id": "uuid",
+      "schedule_type": "group",
+      "title": "영화 관람",
+      "emoji": "🎬",
+      "description": "마블 신작",
+      "description_blocks": [...],
+      "start_at": "ISO8601",
+      "end_at": "ISO8601",
+      "location": { "name": "...", "address": "...", "latitude": 0, "longitude": 0 },
+      "created_at": "ISO8601",
+      "updated_at": "ISO8601",
+
+      "group_id": "uuid",
+      "host_id": "user_id",
+      "minimum_participants": 2,
+      "is_confirmed": true,
+      "vote_deadline": "ISO8601",
+      "tracking_start_minutes_before": 30,
+      "image_urls": ["..."],
+      "votes": {
+        "accepted": ["uid1", "uid2"],
+        "declined": ["uid3"]
+      },
+
+      "reminder_minutes_before": null
+    }
+  }
+  ```
+  - 그룹일정: `votes` 포함 (accepted/declined userId 배열)
+  - 개인일정: 그룹 전용 필드는 null
+- 에러: 403, 404
+
+### PATCH /api/v1/schedules/{id}
+
+- 설명: 일정 수정
+- 인증: 필수
+  - 그룹일정: 약속 호스트 OR 그룹 호스트 (P10), 시작 전만 (P12), LiveActivity 중 불가 (P14)
+  - 개인일정: 소유자만
+- 요청: 수정할 필드만 전송 (Option 패턴)
+  ```json
+  {
+    "title": "수정된 제목",
+    "emoji": "🍿",
+    "description": null,
+    "start_at": "ISO8601",
+    "end_at": "ISO8601",
+    "location": { "name": "새 장소" },
+    "minimum_participants": 3,
+    "tracking_start_minutes_before": 60,
+    "image_urls": ["..."],
+    "reminder_minutes_before": 30
+  }
+  ```
+  - `description`, `emoji`, `location`, `end_at`: `Option<Option<T>>` — 생략=변경없음, null=삭제, 값=변경
+  - start_at 변경 시: vote_deadline 동기화 (P30)
+  - title trim 후 빈 문자열 → 400
+- 응답 200: `{ "data": { "success": true } }`
+- 에러: 400 (유효성), 403 (권한 없음), 404, 409 (시작됨 또는 LA 실행 중)
+
+### DELETE /api/v1/schedules/{id}
+
+- 설명: 일정 삭제 (Hard Delete)
+- 인증: 필수
+  - 그룹일정: 약속 호스트 OR 그룹 호스트 (P11), 시작 전만 (P13)
+  - 개인일정: 소유자만
+- 응답 200: `{ "data": { "success": true } }`
+- 에러: 403, 404, 409 (이미 시작됨)
+
+### POST /api/v1/schedules/{id}/respond
+
+- 설명: 그룹일정 투표 응답
+- 인증: 필수 (같은 그룹 멤버, P15)
+- 요청:
+  ```json
+  { "status": "accepted | declined | pending" }
+  ```
+  - `accepted`: schedule_votes에 INSERT/UPDATE
+  - `declined`: schedule_votes에 INSERT/UPDATE
+  - `pending`: schedule_votes에서 DELETE (P28)
+  - 동일 상태 → no-op (P27)
+  - 트랜잭션 내 is_confirmed 재계산 (P29)
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "schedule_id": "uuid",
+      "status": "accepted",
+      "is_confirmed": true,
+      "confirmed_schedule": {
+        "id": "uuid",
+        "title": "영화 관람",
+        "emoji": "🎬",
+        "start_at": "ISO8601",
+        "end_at": "ISO8601",
+        "location": "CGV 강남",
+        "group_id": "uuid"
+      }
+    }
+  }
+  ```
+  - `confirmed_schedule`: is_confirmed && status==accepted 일 때만 포함 (캘린더 동기화용)
+- 에러: 400 (잘못된 status), 403 (멤버 아님), 404 (일정 없음)
+
+### GET /api/v1/groups/{group_id}/schedules
+
+- 설명: 그룹의 일정 목록 조회
+- 인증: 필수 (그룹 멤버)
+- 쿼리 파라미터:
+  - `status`: `active` (기본값, startAt >= today) | `past` (startAt < now)
+  - `limit`: 최대 개수 (기본 20)
+  - `cursor`: 페이지네이션 커서 (past용, startAt ISO8601)
+- 응답 200:
+  ```json
+  {
+    "data": [ScheduleResponse, ...],
+    "cursor": "ISO8601 | null"
+  }
+  ```
+  - active: startAt 오름차순
+  - past: startAt 내림차순
+- 에러: 403, 404
+
+### GET /api/v1/schedules/home
+
+- 설명: 홈화면 일정 (내 그룹들의 미래 일정, startAt 오름차순)
+- 인증: 필수
+- 쿼리 파라미터:
+  - `limit`: 최대 개수 (기본 20)
+- 응답 200:
+  ```json
+  { "data": [ScheduleResponse, ...] }
+  ```
+  - startAt >= now, 그룹일정만 (내가 속한 모든 그룹)
+  - 클라이언트가 today/upcoming 분리
+
+### GET /api/v1/schedules/calendar
+
+- 설명: 캘린더 날짜 범위 조회 (그룹 + 개인 + 반복)
+- 인증: 필수
+- 쿼리 파라미터:
+  - `start`: 시작 날짜 ISO8601 (필수)
+  - `end`: 종료 날짜 ISO8601 (필수)
+  - `accepted_only`: true이면 내가 accepted한 그룹일정만 (충돌 감지용)
+  - `timezone`: IANA timezone (반복일정 확장용, 기본 UTC)
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "schedules": [ScheduleResponse, ...],
+      "recurring_instances": [
+        {
+          "recurring_schedule_id": "uuid",
+          "title": "헬스장",
+          "emoji": "🏋️",
+          "date": "2026-04-07",
+          "start_time": { "hour": 19, "minute": 0 },
+          "end_time": { "hour": 20, "minute": 0 },
+          "location": { ... }
+        }
+      ]
+    }
+  }
+  ```
+  - 반복일정: 서버에서 규칙 확장하여 인스턴스 배열로 반환
+- 에러: 400 (범위 31일 초과)
+
+### GET /api/v1/schedules/calendar-sync
+
+- 설명: 캘린더 동기화용 경량 조회 (확정 + accepted + 미래)
+- 인증: 필수
+- 응답 200:
+  ```json
+  {
+    "data": [
+      {
+        "id": "uuid",
+        "title": "영화 관람",
+        "emoji": "🎬",
+        "start_at": "ISO8601",
+        "end_at": "ISO8601",
+        "location": "CGV 강남",
+        "group_id": "uuid"
+      }
+    ]
+  }
+  ```
+  - 최대 50개 (P44)
+  - 최소 필드만 반환 (배경 동기화 대역폭 절감)
+
+### POST /api/v1/schedules/check-conflicts
+
+- 설명: 일정 충돌 감지 (Pro 구독 필요)
+- 인증: 필수 (Pro)
+- 요청:
+  ```json
+  {
+    "start_at": "ISO8601",
+    "end_at": "ISO8601 (optional)",
+    "min_gap_minutes": 0,
+    "exclude_ids": ["uuid1"],
+    "timezone": "Asia/Seoul"
+  }
+  ```
+- 응답 200:
+  ```json
+  {
+    "data": [
+      {
+        "id": "uuid",
+        "type": "group | personal | recurring",
+        "title": "기존 일정",
+        "emoji": "📅",
+        "start_at": "ISO8601",
+        "end_at": "ISO8601",
+        "overlap_minutes": 30,
+        "gap_minutes": -30
+      }
+    ]
+  }
+  ```
+  - overlap > 0: 겹침, gap < 0: 겹침, gap >= 0 && gap < minGap: 간격 부족
+  - 정렬: overlap 내림차순 → gap 오름차순
+- 에러: 400, 403 (Pro 아님)
+
+### POST /api/v1/schedules/extract
+
+- 설명: LLM 일정 추출 (Gemini)
+- 인증: 필수
+- 요청:
+  ```json
+  {
+    "text": "SMS 원문 (optional)",
+    "image_base64": "base64 (optional)",
+    "timezone": "Asia/Seoul"
+  }
+  ```
+  - `text` 또는 `image_base64` 중 하나 이상 필수
+  - text 최대 2000자, image 최대 4MB
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "title": "GS25 근무",
+      "emoji": "💼",
+      "start_date": "ISO8601",
+      "end_date": "ISO8601",
+      "location": "장소명",
+      "address": "상세 주소",
+      "description": "plain text",
+      "description_blocks": [...]
+    }
+  }
+  ```
+- 에러: 400 (입력 누락/초과), 500 (추출 실패)
+
+## Recurring Schedules (인증 필요)
+
+### POST /api/v1/recurring-schedules
+
+- 설명: 반복일정 생성
+- 인증: 필수 (본인 소유)
+- 요청:
+  ```json
+  {
+    "title": "헬스장",
+    "emoji": "🏋️",
+    "description": null,
+    "start_time": { "hour": 19, "minute": 0 },
+    "end_time": { "hour": 20, "minute": 0 },
+    "location": { "name": "강남 피트니스", "address": "..." },
+    "reminder_minutes_before": 30,
+    "frequency": "weekly",
+    "days_of_week": [2, 4, 6],
+    "day_of_month": null,
+    "series_start_date": "2026-04-01",
+    "series_end_date": null
+  }
+  ```
+  - frequency별 필수 필드: weekly → days_of_week, monthly → day_of_month
+  - daily → days_of_week/day_of_month 모두 null
+- 응답 201:
+  ```json
+  { "data": { "id": "uuid", "created_at": "ISO8601" } }
+  ```
+- 에러: 400 (유효성)
+
+### GET /api/v1/recurring-schedules
+
+- 설명: 내 반복일정 목록
+- 인증: 필수 (본인 소유만)
+- 응답 200:
+  ```json
+  { "data": [RecurringScheduleResponse, ...] }
+  ```
+
+### PATCH /api/v1/recurring-schedules/{id}
+
+- 설명: 반복일정 수정
+- 인증: 필수 (소유자만)
+- 요청: 수정할 필드만 전송
+  ```json
+  {
+    "title": "수정된 제목",
+    "excluded_dates": ["2026-04-07"],
+    "overrides": {
+      "2026-04-14": { "start_time": { "hour": 20, "minute": 0 } }
+    }
+  }
+  ```
+  - `excluded_dates`: 전체 교체 (배열)
+  - `overrides`: 전체 교체 (Map)
+- 응답 200: `{ "data": { "success": true } }`
+- 에러: 403 (소유자 아님), 404
+
+### DELETE /api/v1/recurring-schedules/{id}
+
+- 설명: 반복일정 삭제
+- 인증: 필수 (소유자만)
+- 응답 200: `{ "data": { "success": true } }`
+- 에러: 403, 404
+
+*마지막 업데이트: 2026-04-06*

--- a/Projects/Clients/Sources/Clients/FeatureFlagsClient.swift
+++ b/Projects/Clients/Sources/Clients/FeatureFlagsClient.swift
@@ -25,7 +25,7 @@ extension FeatureFlagsClient: DependencyKey {
   public static let liveValue = Self(
     useRustAPI: { domain in
       #if DEBUG
-      if domain == .users { return true }
+      return true  // Dev 빌드: 전체 도메인 Rust API 사용
       #endif
       return UserDefaults.standard.bool(forKey: "rust_api_\(domain.rawValue)")
     }

--- a/Projects/Clients/Sources/Clients/ScheduleClient.swift
+++ b/Projects/Clients/Sources/Clients/ScheduleClient.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import FirebaseAuth
 import Foundation
 import Combine
 import PromisoShared
@@ -259,69 +260,161 @@ extension DependencyValues {
 
 extension ScheduleClient: DependencyKey {
   public static let liveValue: ScheduleClient = {
+    @Dependency(\.featureFlags) var featureFlags
     let dataSource: ScheduleRemoteDataSourceProtocol = ScheduleRemoteDataSource()
+    let rustDataSource = ScheduleRustDataSource(
+      api: RustAPIClient(
+        getAuthToken: {
+          guard let firebaseUser = Auth.auth().currentUser else {
+            throw ScheduleClientError.unauthorized
+          }
+          return try await firebaseUser.getIDToken()
+        }
+      )
+    )
 
     return ScheduleClient(
       createSchedule: { schedule in
-        guard !schedule.groupId.isEmpty else {
-          throw ScheduleClientError.invalidData(nil)
-        }
-
-        do {
-          return try await dataSource.createSchedule(schedule)
-        } catch {
-          throw ScheduleClientError(from: error)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.createSchedule(schedule)
+        } else {
+          guard !schedule.groupId.isEmpty else {
+            throw ScheduleClientError.invalidData(nil)
+          }
+          do {
+            return try await dataSource.createSchedule(schedule)
+          } catch {
+            throw ScheduleClientError(from: error)
+          }
         }
       },
       updateSchedule: { schedule in
-        try await dataSource.updateSchedule(schedule)
+        if featureFlags.useRustAPI(.promises) {
+          try await rustDataSource.updateSchedule(schedule)
+        } else {
+          try await dataSource.updateSchedule(schedule)
+        }
       },
       deleteSchedule: { scheduleId in
-        try await dataSource.deleteSchedule(id: scheduleId)
+        if featureFlags.useRustAPI(.promises) {
+          try await rustDataSource.deleteSchedule(id: scheduleId)
+        } else {
+          try await dataSource.deleteSchedule(id: scheduleId)
+        }
       },
       getSchedule: { scheduleId in
-        try await dataSource.getSchedule(id: scheduleId)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getSchedule(id: scheduleId)
+        } else {
+          return try await dataSource.getSchedule(id: scheduleId)
+        }
       },
       getTodaySchedules: { groupIds in
-        try await dataSource.getTodaySchedules(groupIds: groupIds)
+        if featureFlags.useRustAPI(.promises) {
+          // Rust API: /home 엔드포인트로 대체 후 클라이언트에서 today 필터링
+          let schedules = try await rustDataSource.getHomeSchedules(groupIds: groupIds, limitPerChunk: 20)
+          let calendar = Calendar.current
+          let startOfDay = calendar.startOfDay(for: Date())
+          guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else { return [] }
+          return schedules.filter { $0.startAt >= startOfDay && $0.startAt < endOfDay }
+        } else {
+          return try await dataSource.getTodaySchedules(groupIds: groupIds)
+        }
       },
       getUpcomingSchedules: { groupIds, limit in
-        try await dataSource.getUpcomingSchedules(groupIds: groupIds, limit: limit)
+        if featureFlags.useRustAPI(.promises) {
+          // Rust API: /home 엔드포인트로 대체
+          let schedules = try await rustDataSource.getHomeSchedules(groupIds: groupIds, limitPerChunk: limit)
+          return Array(schedules.prefix(limit))
+        } else {
+          return try await dataSource.getUpcomingSchedules(groupIds: groupIds, limit: limit)
+        }
       },
       getActiveSchedules: { groupId, limit in
-        try await dataSource.getActiveSchedules(groupId: groupId, limit: limit)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getActiveSchedules(groupId: groupId, limit: limit)
+        } else {
+          return try await dataSource.getActiveSchedules(groupId: groupId, limit: limit)
+        }
       },
       getPastSchedules: { groupId, limit, lastStartAt in
-        try await dataSource.getPastSchedules(groupId: groupId, limit: limit, lastStartAt: lastStartAt)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getPastSchedules(groupId: groupId, limit: limit, lastStartAt: lastStartAt)
+        } else {
+          return try await dataSource.getPastSchedules(groupId: groupId, limit: limit, lastStartAt: lastStartAt)
+        }
       },
       getActiveScheduleCount: { groupId in
-        try await dataSource.getActiveScheduleCount(groupId: groupId)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getActiveScheduleCount(groupId: groupId)
+        } else {
+          return try await dataSource.getActiveScheduleCount(groupId: groupId)
+        }
       },
       getSchedulesByDateRange: { groupIds, startDate, endDate in
-        try await dataSource.getSchedulesByDateRange(groupIds: groupIds, startDate: startDate, endDate: endDate)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getSchedulesByDateRange(
+            groupIds: groupIds,
+            startDate: startDate,
+            endDate: endDate
+          )
+        } else {
+          return try await dataSource.getSchedulesByDateRange(
+            groupIds: groupIds,
+            startDate: startDate,
+            endDate: endDate
+          )
+        }
       },
       getHomeSchedules: { groupIds, limitPerChunk in
-        try await dataSource.getHomeSchedules(groupIds: groupIds, limitPerChunk: limitPerChunk)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getHomeSchedules(groupIds: groupIds, limitPerChunk: limitPerChunk)
+        } else {
+          return try await dataSource.getHomeSchedules(groupIds: groupIds, limitPerChunk: limitPerChunk)
+        }
       },
       subscribeToSchedules: { groupId, limit in
+        // Real-time listener: Firebase only (no Rust equivalent)
         dataSource.subscribeToActiveSchedules(groupId: groupId, limit: limit)
       },
       respondSchedule: { scheduleId, status in
-        return try await dataSource.respondToSchedule(
-          scheduleId: scheduleId,
-          status: status.rawValue
-        )
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.respondToSchedule(
+            scheduleId: scheduleId,
+            status: status.rawValue
+          )
+        } else {
+          return try await dataSource.respondToSchedule(
+            scheduleId: scheduleId,
+            status: status.rawValue
+          )
+        }
       },
       getAcceptedSchedulesByDateRange: { startDate, endDate in
-        do {
-          return try await dataSource.getAcceptedSchedulesByDateRange(startDate: startDate, endDate: endDate)
-        } catch {
-          throw ScheduleClientError(from: error)
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getAcceptedSchedulesByDateRange(
+            startDate: startDate,
+            endDate: endDate
+          )
+        } else {
+          do {
+            return try await dataSource.getAcceptedSchedulesByDateRange(
+              startDate: startDate,
+              endDate: endDate
+            )
+          } catch {
+            throw ScheduleClientError(from: error)
+          }
         }
       },
       getConfirmedSchedulesForCalendar: {
-        try await dataSource.getConfirmedSchedulesForCalendar()
+        if featureFlags.useRustAPI(.promises) {
+          return try await rustDataSource.getConfirmedSchedulesForCalendar()
+        } else {
+          return try await dataSource.getConfirmedSchedulesForCalendar()
+        }
       },
+      // LiveActivity: Firebase only (no Rust equivalent yet)
       startLiveActivity: { scheduleId in
         try await dataSource.startLiveActivity(scheduleId: scheduleId)
       },

--- a/Projects/Clients/Sources/Data/DataSources/Implementations/ScheduleRustDataSource.swift
+++ b/Projects/Clients/Sources/Data/DataSources/Implementations/ScheduleRustDataSource.swift
@@ -1,0 +1,544 @@
+import Foundation
+import PromisoShared
+
+// MARK: - Response DTOs
+
+/// 일정 생성 응답
+private struct RustCreateScheduleResponse: Decodable {
+  let scheduleId: String
+  let title: String
+  let groupId: String?
+  let startAt: Date
+  let isConfirmed: Bool?
+}
+
+/// 일정 상세 응답
+private struct RustScheduleResponse: Decodable {
+  let id: String
+  let scheduleType: String
+  let userId: String?
+  let title: String
+  let emoji: String?
+  let description: String?
+  let descriptionBlocks: [RustDescriptionBlockDTO]?
+  let startAt: Date
+  let endAt: Date?
+  let location: RustLocationResponse?
+  let createdAt: Date
+  let updatedAt: Date
+  // group fields
+  let groupId: String?
+  let hostId: String?
+  let minimumParticipants: Int?
+  let isConfirmed: Bool?
+  let voteDeadline: Date?
+  let trackingStartMinutesBefore: Int?
+  let imageUrls: [String]?
+  let votes: RustVotesResponse?
+  // personal fields
+  let reminderMinutesBefore: Int?
+}
+
+private struct RustLocationResponse: Decodable {
+  let name: String
+  let address: String?
+  let latitude: Double?
+  let longitude: Double?
+}
+
+private struct RustVotesResponse: Decodable {
+  let accepted: [String]
+  let declined: [String]
+}
+
+private struct RustDescriptionBlockDTO: Decodable {
+  let type: String
+  let content: String?
+  let items: [RustChecklistItemDTO]?
+  let bulletItems: [String]?
+
+  private enum CodingKeys: String, CodingKey {
+    case type, content, items
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    type = try container.decode(String.self, forKey: .type)
+    content = try container.decodeIfPresent(String.self, forKey: .content)
+
+    switch type {
+    case "checklist":
+      items = try container.decodeIfPresent([RustChecklistItemDTO].self, forKey: .items)
+      bulletItems = nil
+    case "bulletList":
+      items = nil
+      bulletItems = try container.decodeIfPresent([String].self, forKey: .items)
+    default:
+      items = nil
+      bulletItems = nil
+    }
+  }
+}
+
+private struct RustChecklistItemDTO: Decodable {
+  let id: String
+  let text: String
+  let isChecked: Bool
+}
+
+/// 투표 응답
+private struct RustRespondScheduleResponse: Decodable {
+  let scheduleId: String
+  let status: String
+  let isConfirmed: Bool
+  let confirmedSchedule: RustCalendarSyncSchedule?
+}
+
+private struct RustCalendarSyncSchedule: Decodable {
+  let id: String
+  let title: String
+  let emoji: String?
+  let startAt: Date
+  let endAt: Date?
+  let location: String?
+  let groupId: String
+}
+
+/// 페이지네이션 응답 (그룹 일정 목록)
+private struct RustPaginatedScheduleResponse: Decodable {
+  let data: [RustScheduleResponse]
+  let cursor: Date?
+}
+
+/// 캘린더 응답
+private struct RustCalendarResponse: Decodable {
+  let schedules: [RustScheduleResponse]
+  let recurringInstances: [RustRecurringInstance]?
+}
+
+private struct RustRecurringInstance: Decodable {
+  let recurringScheduleId: String
+  let title: String
+  let emoji: String?
+  let date: String
+  let startTime: RustTimeComponents
+  let endTime: RustTimeComponents?
+  let location: RustLocationResponse?
+}
+
+private struct RustTimeComponents: Decodable {
+  let hour: Int
+  let minute: Int
+}
+
+/// 캘린더 동기화 응답 (경량)
+private struct RustCalendarSyncResponse: Decodable {
+  let id: String
+  let title: String
+  let emoji: String?
+  let startAt: Date
+  let endAt: Date?
+  let location: String?
+  let groupId: String
+}
+
+/// 활성 일정 개수 응답
+private struct RustActiveCountResponse: Decodable {
+  let count: Int
+}
+
+private struct RustSuccessResponse: Decodable {
+  let success: Bool?
+}
+
+// MARK: - Request Bodies
+
+private struct CreateScheduleBody: Encodable {
+  let scheduleType: String
+  let groupId: String?
+  let title: String
+  let emoji: String?
+  let description: String?
+  let descriptionBlocks: [DescriptionBlock]?
+  let startAt: Date
+  let endAt: Date?
+  let location: LocationBody?
+  let minimumParticipants: Int?
+  let trackingStartMinutesBefore: Int?
+  let imageUrls: [String]?
+  let reminderMinutesBefore: Int?
+}
+
+private struct LocationBody: Encodable {
+  let name: String
+  let address: String?
+  let latitude: Double?
+  let longitude: Double?
+}
+
+private struct UpdateScheduleBody: Encodable {
+  let title: String?
+  let emoji: String??
+  let description: String??
+  let descriptionBlocks: [DescriptionBlock]??
+  let startAt: Date?
+  let endAt: Date??
+  let location: LocationBody??
+  let minimumParticipants: Int?
+  let trackingStartMinutesBefore: Int??
+  let imageUrls: [String]??
+  let reminderMinutesBefore: Int??
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(title, forKey: .title)
+
+    // emoji: Option<Option<String>>
+    switch emoji {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .emoji)
+    case .some(.some(let v)): try container.encode(v, forKey: .emoji)
+    }
+
+    // description: Option<Option<String>>
+    switch description {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .description)
+    case .some(.some(let v)): try container.encode(v, forKey: .description)
+    }
+
+    // descriptionBlocks: Option<Option<[DescriptionBlock]>>
+    switch descriptionBlocks {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .descriptionBlocks)
+    case .some(.some(let v)): try container.encode(v, forKey: .descriptionBlocks)
+    }
+
+    try container.encodeIfPresent(startAt, forKey: .startAt)
+
+    // endAt: Option<Option<Date>>
+    switch endAt {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .endAt)
+    case .some(.some(let v)): try container.encode(v, forKey: .endAt)
+    }
+
+    // location: Option<Option<LocationBody>>
+    switch location {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .location)
+    case .some(.some(let v)): try container.encode(v, forKey: .location)
+    }
+
+    try container.encodeIfPresent(minimumParticipants, forKey: .minimumParticipants)
+
+    // trackingStartMinutesBefore: Option<Option<Int>>
+    switch trackingStartMinutesBefore {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .trackingStartMinutesBefore)
+    case .some(.some(let v)): try container.encode(v, forKey: .trackingStartMinutesBefore)
+    }
+
+    // imageUrls: Option<Option<[String]>>
+    switch imageUrls {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .imageUrls)
+    case .some(.some(let v)): try container.encode(v, forKey: .imageUrls)
+    }
+
+    // reminderMinutesBefore: Option<Option<Int>>
+    switch reminderMinutesBefore {
+    case .none: break
+    case .some(.none): try container.encodeNil(forKey: .reminderMinutesBefore)
+    case .some(.some(let v)): try container.encode(v, forKey: .reminderMinutesBefore)
+    }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case title, emoji, description, descriptionBlocks, startAt, endAt
+    case location, minimumParticipants, trackingStartMinutesBefore
+    case imageUrls, reminderMinutesBefore
+  }
+}
+
+private struct RespondScheduleBody: Encodable {
+  let status: String
+}
+
+private struct EmptyBody: Encodable {}
+
+// MARK: - ScheduleRustDataSource
+
+public actor ScheduleRustDataSource {
+  private let api: RustAPIClient
+
+  public init(api: RustAPIClient) {
+    self.api = api
+  }
+
+  // MARK: - Create
+
+  public func createSchedule(_ schedule: ScheduleModel) async throws -> String {
+    let locationBody: LocationBody? = schedule.location.flatMap { loc in
+      guard !loc.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+      return LocationBody(
+        name: loc.name,
+        address: loc.address,
+        latitude: loc.latitude,
+        longitude: loc.longitude
+      )
+    }
+
+    let body = CreateScheduleBody(
+      scheduleType: schedule.groupId.isEmpty ? "personal" : "group",
+      groupId: schedule.groupId.isEmpty ? nil : schedule.groupId,
+      title: schedule.title,
+      emoji: schedule.emoji?.isEmpty == true ? nil : schedule.emoji,
+      description: schedule.description?.isEmpty == true ? nil : schedule.description,
+      descriptionBlocks: schedule.descriptionBlocks.isEmpty ? nil : schedule.descriptionBlocks,
+      startAt: schedule.startAt,
+      endAt: schedule.endAt,
+      location: locationBody,
+      minimumParticipants: schedule.groupId.isEmpty ? nil : schedule.minimumParticipants,
+      trackingStartMinutesBefore: schedule.trackingStartMinutesBefore,
+      imageUrls: schedule.imageUrls.isEmpty ? nil : schedule.imageUrls,
+      reminderMinutesBefore: nil
+    )
+
+    let response: RustCreateScheduleResponse = try await api.post("/api/v1/schedules", body: body)
+    return response.scheduleId
+  }
+
+  // MARK: - Read
+
+  public func getSchedule(id: String) async throws -> ScheduleModel? {
+    let response: RustScheduleResponse = try await api.get("/api/v1/schedules/\(id)")
+    return response.toScheduleModel()
+  }
+
+  // MARK: - Update
+
+  public func updateSchedule(_ schedule: ScheduleModel) async throws {
+    let locationBody: LocationBody?? = {
+      if let loc = schedule.location,
+         !loc.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return .some(LocationBody(
+          name: loc.name,
+          address: loc.address,
+          latitude: loc.latitude,
+          longitude: loc.longitude
+        ))
+      } else {
+        return .some(nil)
+      }
+    }()
+
+    let body = UpdateScheduleBody(
+      title: schedule.title,
+      emoji: .some(schedule.emoji),
+      description: .some(schedule.description),
+      descriptionBlocks: schedule.descriptionBlocks.isEmpty ? .some(nil) : .some(schedule.descriptionBlocks),
+      startAt: schedule.startAt,
+      endAt: .some(schedule.endAt),
+      location: locationBody,
+      minimumParticipants: schedule.minimumParticipants,
+      trackingStartMinutesBefore: .some(schedule.trackingStartMinutesBefore),
+      imageUrls: schedule.imageUrls.isEmpty ? .some(nil) : .some(schedule.imageUrls),
+      reminderMinutesBefore: nil
+    )
+
+    let _: RustSuccessResponse = try await api.patch("/api/v1/schedules/\(schedule.id)", body: body)
+  }
+
+  // MARK: - Delete
+
+  public func deleteSchedule(id: String) async throws {
+    let _: RustSuccessResponse = try await api.delete("/api/v1/schedules/\(id)")
+  }
+
+  // MARK: - Respond
+
+  public func respondToSchedule(scheduleId: String, status: String) async throws -> RespondScheduleResult {
+    let body = RespondScheduleBody(status: status)
+    let response: RustRespondScheduleResponse = try await api.post(
+      "/api/v1/schedules/\(scheduleId)/respond",
+      body: body
+    )
+
+    let confirmedSchedule: CalendarSyncSchedule? = response.confirmedSchedule.map { cs in
+      CalendarSyncSchedule(
+        id: cs.id,
+        title: cs.title,
+        emoji: cs.emoji ?? "",
+        startAt: cs.startAt,
+        endAt: cs.endAt,
+        location: cs.location,
+        groupId: cs.groupId
+      )
+    }
+
+    return RespondScheduleResult(
+      scheduleId: response.scheduleId,
+      status: response.status,
+      isConfirmed: response.isConfirmed,
+      confirmedSchedule: confirmedSchedule
+    )
+  }
+
+  // MARK: - Group Schedules
+
+  public func getActiveSchedules(groupId: String, limit: Int) async throws -> [ScheduleModel] {
+    let response: [RustScheduleResponse] = try await api.get(
+      "/api/v1/groups/\(groupId)/schedules?status=active&limit=\(limit)"
+    )
+    return response.map { $0.toScheduleModel() }
+  }
+
+  public func getPastSchedules(groupId: String, limit: Int, lastStartAt: Date?) async throws -> [ScheduleModel] {
+    var path = "/api/v1/groups/\(groupId)/schedules?status=past&limit=\(limit)"
+    if let cursor = lastStartAt {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      let cursorString = formatter.string(from: cursor)
+        .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+      path += "&cursor=\(cursorString)"
+    }
+    let response: [RustScheduleResponse] = try await api.get(path)
+    return response.map { $0.toScheduleModel() }
+  }
+
+  public func getActiveScheduleCount(groupId: String) async throws -> Int {
+    let schedules: [RustScheduleResponse] = try await api.get(
+      "/api/v1/groups/\(groupId)/schedules?status=active&limit=100"
+    )
+    return schedules.count
+  }
+
+  // MARK: - Home Schedules
+
+  public func getHomeSchedules(groupIds: [String], limitPerChunk: Int) async throws -> [ScheduleModel] {
+    guard !groupIds.isEmpty else { return [] }
+    let limit = limitPerChunk * max(1, groupIds.count / 10 + 1)
+    let response: [RustScheduleResponse] = try await api.get(
+      "/api/v1/schedules/home?limit=\(limit)"
+    )
+    return response.map { $0.toScheduleModel() }
+  }
+
+  // MARK: - Calendar
+
+  public func getSchedulesByDateRange(
+    groupIds: [String],
+    startDate: Date,
+    endDate: Date
+  ) async throws -> [ScheduleModel] {
+    guard !groupIds.isEmpty else { return [] }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let startString = formatter.string(from: startDate)
+      .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let endString = formatter.string(from: endDate)
+      .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let response: RustCalendarResponse = try await api.get(
+      "/api/v1/schedules/calendar?start=\(startString)&end=\(endString)"
+    )
+    return response.schedules.map { $0.toScheduleModel() }
+  }
+
+  public func getAcceptedSchedulesByDateRange(
+    startDate: Date,
+    endDate: Date
+  ) async throws -> [ScheduleModel] {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let startString = formatter.string(from: startDate)
+      .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let endString = formatter.string(from: endDate)
+      .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let response: RustCalendarResponse = try await api.get(
+      "/api/v1/schedules/calendar?start=\(startString)&end=\(endString)&accepted_only=true"
+    )
+    return response.schedules.map { $0.toScheduleModel() }
+  }
+
+  // MARK: - Calendar Sync
+
+  public func getConfirmedSchedulesForCalendar() async throws -> [CalendarSyncSchedule] {
+    let response: [RustCalendarSyncResponse] = try await api.get("/api/v1/schedules/calendar-sync")
+    return response.map { item in
+      CalendarSyncSchedule(
+        id: item.id,
+        title: item.title,
+        emoji: item.emoji ?? "",
+        startAt: item.startAt,
+        endAt: item.endAt,
+        location: item.location,
+        groupId: item.groupId
+      )
+    }
+  }
+}
+
+// MARK: - DTO -> Model
+
+extension RustScheduleResponse {
+  fileprivate func toScheduleModel() -> ScheduleModel {
+    let locationModel: LocationInfoModel? = location.map {
+      LocationInfoModel(
+        name: $0.name,
+        address: $0.address,
+        latitude: $0.latitude,
+        longitude: $0.longitude
+      )
+    }
+
+    let descBlocks: [DescriptionBlock] = descriptionBlocks?.compactMap { dto in
+      switch dto.type {
+      case "text":
+        guard let content = dto.content else { return nil }
+        return DescriptionBlock(content: .text(content))
+      case "checklist":
+        guard let items = dto.items else { return nil }
+        let checklistItems = items.map {
+          ChecklistItem(id: $0.id, text: $0.text, isChecked: $0.isChecked)
+        }
+        return DescriptionBlock(content: .checklist(checklistItems))
+      case "bulletList":
+        guard let bulletItems = dto.bulletItems else { return nil }
+        return DescriptionBlock(content: .bulletList(bulletItems))
+      default:
+        if let content = dto.content {
+          return DescriptionBlock(content: .text(content))
+        }
+        return nil
+      }
+    } ?? (description.map { [DescriptionBlock(content: .text($0))] } ?? [])
+
+    let votesModel: ScheduleVotesModel = {
+      let accepted = votes?.accepted ?? []
+      let declined = votes?.declined ?? []
+      let until = voteDeadline ?? startAt
+      return ScheduleVotesModel(accepted: accepted, declined: declined, until: until)
+    }()
+
+    return ScheduleModel(
+      id: id,
+      title: title,
+      emoji: emoji,
+      description: description,
+      descriptionBlocks: descBlocks,
+      hostId: hostId ?? userId ?? "",
+      groupId: groupId ?? "",
+      group: nil,
+      minimumParticipants: minimumParticipants ?? 1,
+      votes: votesModel,
+      startAt: startAt,
+      endAt: endAt,
+      location: locationModel,
+      imageUrls: imageUrls ?? [],
+      trackingStartMinutesBefore: trackingStartMinutesBefore,
+      createdAt: createdAt,
+      updatedAt: updatedAt
+    )
+  }
+}

--- a/docs/blog/00-roadmap.md
+++ b/docs/blog/00-roadmap.md
@@ -7,14 +7,13 @@
 - [x] #1 왜 Firebase를 떠나는가 — 동기, 기술 선택, 마이그레이션 전략
 - [x] #2 서버 뼈대 잡기 — 인프라 선택(DB, 배포, 인증, 스토리지)부터 Axum + SQLx 환경 구축까지
 - [x] #3 그룹 API 구현 — Firestore → PostgreSQL 스키마 설계 + 초대/가입/권한 로직
-- [ ] #4 일정 API 구현 — 개인일정/그룹일정 스키마 + 응답/확정 상태 머신
+- [x] #4 일정 API 구현 — 개인일정/그룹일정 스키마 + 응답/확정 상태 머신
 - [ ] #5 알림과 푸시 — FCM 직접 발송 + 배지 + 그룹별 설정
-- [ ] #6 실시간 — Firestore Listener → SSE/WebSocket
-- [ ] #7 고급 기능 — LiveActivity, 위젯, 쿠폰, AI 브리핑
-- [ ] #8 배포 파이프라인 — Cloud Run + GitHub Actions CI/CD
-- [ ] #9 점진적 전환 — Branch by Abstraction으로 Dev → Stage → Prod
-- [ ] #10 인증 자체 구현 — Firebase Auth → Apple/Google OAuth + JWT (선택적)
-- [ ] #11 회고 — Firebase vs 자체 서버, 실제로 뭐가 달라졌나
+- [ ] #6 실시간과 LiveActivity — SSE + APNs 직접 발송 + ETA 공유
+- [ ] #7 나머지 기능 — 위젯, 쿠폰, AI 브리핑, 배포 파이프라인
+- [ ] #8 점진적 전환 — Branch by Abstraction으로 Dev → Stage → Prod
+- [ ] #9 인증 자체 구현 — Firebase Auth → Apple/Google OAuth + JWT (선택적)
+- [ ] #10 회고 — Firebase vs 자체 서버, 실제로 뭐가 달라졌나
 
 ## 메모
 

--- a/docs/blog/04-schedule-api.en.md
+++ b/docs/blog/04-schedule-api.en.md
@@ -1,0 +1,344 @@
+# From Firebase to Rust -- Schedule API: The Vote State Machine and Three Collections
+
+*An iOS App Server Migration #4 -- Merging Group Schedules, Personal Events, and Recurring Events into One Table*
+
+---
+
+In Firestore, schedule-related data is scattered across three locations.
+
+`promises/{id}` -- group schedules. Votes (a Map), confirmation status, location, images.
+`users/{uid}/personalEvents/{id}` -- personal events. Private schedules only visible to the owner.
+`users/{uid}/scheduleSlots/{YYYY-MM-DD}` -- denormalized slots for conflict detection. Copies of schedule fragments, organized by date.
+
+All three need to merge on the calendar screen. Group and personal schedules displayed together in chronological order, and when creating a new schedule, you need to check if it overlaps with existing ones. In Firestore, that means querying three separate collections, merging on the client, and sorting.
+
+Conflict detection was particularly painful. Firestore can't do "query all schedules for this user within a time range" in a single call. So I built a denormalized collection called `scheduleSlots`. When a schedule is created, a trigger copies a slot entry into the corresponding date document. When a schedule changes, the old slot gets removed and a new one inserted. When deleted, the slot goes too. Three triggers for group schedules, three for personal events, one for querying. Seven Cloud Functions triggers maintaining this denormalization.
+
+These triggers are fragile. When a schedule's time changes, you need to remove the slot from the old date and add it to the new one -- which means carrying both the previous and new `startAt` through the trigger. When vote status changes, only the accepting member's slot should be added or removed. Recurring events don't have slots at all -- they're expanded at query time. The result: three separate data paths just for conflict detection.
+
+Moving to PostgreSQL, I had one question. Of all this complexity, how much is business logic and how much is a Firestore workaround?
+
+---
+
+## Three Collections, One Table
+
+The short answer: I merged `promises` + `personalEvents` into a single `schedules` table. `scheduleSlots` was deleted entirely.
+
+```sql
+CREATE TABLE schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_type schedule_type NOT NULL,  -- 'group' | 'personal'
+  user_id TEXT NOT NULL REFERENCES users(id),
+
+  title TEXT NOT NULL,
+  emoji TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ,
+  -- ... shared fields ...
+
+  -- Group schedule only (NULL for personal)
+  group_id UUID REFERENCES groups(id),
+  minimum_participants SMALLINT,
+  is_confirmed BOOLEAN,
+  vote_deadline TIMESTAMPTZ,
+
+  -- Personal schedule only (NULL for group)
+  reminder_minutes_before SMALLINT,
+
+  CONSTRAINT chk_schedule_type_fields CHECK (
+    (schedule_type = 'group'
+      AND group_id IS NOT NULL
+      AND minimum_participants IS NOT NULL)
+    OR
+    (schedule_type = 'personal'
+      AND group_id IS NULL
+      AND minimum_participants IS NULL)
+  )
+);
+```
+
+A `schedule_type` enum distinguishes the two, and a CHECK constraint enforces type-specific fields. A group schedule without `group_id`? INSERT fails. A personal schedule with `minimum_participants`? Also fails. The database enforces the rules.
+
+Why merge? Look at why they were separated in Firestore. `promises` is a top-level collection; `personalEvents` is a user subcollection. This split exists because of security rules. Firestore security rules are path-based. Putting events under `users/{uid}/personalEvents/{id}` lets you enforce "owner-only access" with a single path pattern. `promises` needs to be readable by all group members, so it sits in its own collection with a separate membership check.
+
+In PostgreSQL, security isn't path-based -- it lives in the API layer. The service function checks "if personal, verify `user_id` matches; if group, verify group membership" in code. The reason for separation is gone, and a reason to merge has appeared: the calendar can query both types in a single SQL statement.
+
+Recurring events (`recurringEvents`) stayed in a separate `recurring_schedules` table. Not because I was following Firestore's structure, but because they're fundamentally different entities. `schedules` stores concrete moments -- "Movie at 2pm on April 7th." `recurring_schedules` stores rules -- "Gym every Mon/Wed/Fri at 7pm." The field structures are completely different: one has `start_at: TIMESTAMPTZ`, the other has `start_time_hour: SMALLINT` + `start_time_minute: SMALLINT`.
+
+---
+
+## scheduleSlots, Gone
+
+The seven triggers maintaining `scheduleSlots` are replaced by a single SQL query.
+
+```sql
+-- All schedules for a user within a time range (conflict detection)
+SELECT s.id, s.title, s.start_at, s.end_at
+FROM schedules s
+JOIN schedule_votes sv ON sv.schedule_id = s.id
+WHERE sv.user_id = $1 AND sv.status = 'accepted'
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL)
+UNION ALL
+SELECT s.id, s.title, s.start_at, s.end_at
+FROM schedules s
+WHERE s.schedule_type = 'personal' AND s.user_id = $1
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL);
+```
+
+Group schedules JOIN with `schedule_votes` to get only the ones I accepted. Personal schedules filter by `user_id` directly. Two indexes are enough.
+
+```sql
+CREATE INDEX idx_schedule_votes_user ON schedule_votes (user_id, status);
+CREATE INDEX idx_schedules_personal_start ON schedules (user_id, start_at)
+  WHERE schedule_type = 'personal';
+```
+
+The denormalization existed because Firestore can't do "range queries across multiple collections." SQL handles that with JOIN + WHERE. Seven triggers, slot creation/deletion/update logic, date key calculation code -- all gone.
+
+---
+
+## The Vote State Machine
+
+The core of group schedules is voting. Members accept or decline, and when the minimum headcount is reached, the schedule is confirmed.
+
+In Firestore, votes are a Map:
+
+```json
+{
+  "votes": {
+    "accepted": ["user_A", "user_B"],
+    "declined": ["user_C"],
+    "until": "2026-04-10T19:00:00+09:00"
+  },
+  "minimumParticipants": 2,
+  "isConfirmed": true
+}
+```
+
+`accepted` and `declined` are userId arrays. Pending isn't stored -- it's computed as "group members minus accepted minus declined." `isConfirmed` is a denormalized field: `accepted.length >= minimumParticipants`.
+
+This structure was tailored for Firestore. `arrayUnion`/`arrayRemove` let you treat arrays as sets, and a single document listener catches all vote changes.
+
+In PostgreSQL, it becomes a normalized table.
+
+```sql
+CREATE TABLE schedule_votes (
+  schedule_id UUID REFERENCES schedules(id) ON DELETE CASCADE,
+  user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+  status vote_status NOT NULL,  -- 'accepted' | 'declined'
+  responded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (schedule_id, user_id)
+);
+```
+
+Pending still isn't stored. If someone is in `group_members` but not in `schedule_votes`, they're pending. Same principle as Firebase.
+
+The vote response logic runs inside a transaction.
+
+```rust
+let mut tx = pool.begin().await?;
+
+match status {
+    "accepted" | "declined" => {
+        // UPSERT -- if already voted, just update the status
+        sqlx::query(
+            "INSERT INTO schedule_votes (schedule_id, user_id, status)
+             VALUES ($1, $2, $3::vote_status)
+             ON CONFLICT (schedule_id, user_id)
+             DO UPDATE SET status = $3::vote_status, responded_at = NOW()"
+        )
+        .bind(schedule_id).bind(user_id).bind(status)
+        .execute(&mut *tx).await?;
+    }
+    "pending" => {
+        // Canceling a vote = deleting the row entirely
+        sqlx::query(
+            "DELETE FROM schedule_votes
+             WHERE schedule_id = $1 AND user_id = $2"
+        )
+        .bind(schedule_id).bind(user_id)
+        .execute(&mut *tx).await?;
+    }
+}
+
+// Recalculate is_confirmed -- in the same transaction
+let accepted_count: i64 = sqlx::query_scalar(
+    "SELECT COUNT(*) FROM schedule_votes
+     WHERE schedule_id = $1 AND status = 'accepted'"
+)
+.bind(schedule_id)
+.fetch_one(&mut *tx).await?;
+
+let new_confirmed = accepted_count >= minimum_participants as i64;
+sqlx::query("UPDATE schedules SET is_confirmed = $1 WHERE id = $2")
+    .bind(new_confirmed).bind(schedule_id)
+    .execute(&mut *tx).await?;
+
+tx.commit().await?;
+```
+
+Firestore did the same thing inside `runTransaction`. The difference is `INSERT ON CONFLICT` and `DELETE` instead of `arrayUnion`/`arrayRemove`, and `COUNT(*)` instead of array length. The business rules are identical; only the expression changes.
+
+I kept `is_confirmed` as a separate column for query performance. Calendar sync needs "confirmed future schedules," and `WHERE is_confirmed = TRUE AND start_at >= NOW()` is one line with a clear index path. Better than counting votes every time.
+
+---
+
+## Mutual Exclusion in Recurring Schedules
+
+The fun part of the recurring schedule schema was the CHECK constraint.
+
+```sql
+CONSTRAINT chk_recurrence_fields CHECK (
+  (frequency = 'daily'
+    AND days_of_week IS NULL
+    AND day_of_month IS NULL)
+  OR
+  (frequency = 'weekly'
+    AND days_of_week IS NOT NULL
+    AND array_length(days_of_week, 1) > 0
+    AND day_of_month IS NULL)
+  OR
+  (frequency = 'monthly'
+    AND days_of_week IS NULL
+    AND day_of_month IS NOT NULL
+    AND day_of_month BETWEEN 1 AND 31)
+)
+```
+
+Daily but `days_of_week` is set? INSERT fails. Weekly but `days_of_week` is empty? Fails. Monthly but no `day_of_month`? Fails. Even if the service code misses a validation, the database catches it.
+
+In Swift, you'd express this mutual exclusion with an enum with associated values:
+
+```swift
+enum Recurrence {
+    case daily
+    case weekly(daysOfWeek: [Int])
+    case monthly(dayOfMonth: Int)
+}
+```
+
+The type system guarantees "weekly always has daysOfWeek" at compile time. SQL's CHECK constraint provides the same guarantee at runtime, at the database level. Different layer, same purpose.
+
+---
+
+## Code: Before/After
+
+### Creating a Schedule
+
+In Firebase, group schedules and personal events take completely different paths.
+
+```typescript
+// Firebase: group schedule -- Cloud Function
+export const createPromise = onCall(async (request) => {
+  const promiseRef = promisesCollection.doc();
+  await promiseRef.set({
+    title, groupId, hostId: userId,
+    votes: { accepted: [userId], declined: [], until: startAt },
+    isConfirmed: initialAccepted.length >= minimumParticipants,
+    // ... 20 more lines ...
+  });
+  return { promiseId: promiseRef.id };
+});
+
+// Firebase: personal event -- client writes to Firestore directly
+db.collection("users").document(userId)
+  .collection("personalEvents").addDocument(data: [...])
+```
+
+In Rust, it's a single function that branches on `schedule_type`.
+
+```rust
+pub async fn create_schedule(
+    pool: &PgPool, user_id: &str, req: CreateScheduleRequest
+) -> Result<CreateScheduleResponse, AppError> {
+    match req.schedule_type {
+        ScheduleType::Group => {
+            // Check group membership + INSERT + auto-accept host vote
+            let mut tx = pool.begin().await?;
+            let schedule = sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (...) VALUES (...) RETURNING *"
+            ).fetch_one(&mut *tx).await?;
+
+            // Host auto-accepted
+            sqlx::query("INSERT INTO schedule_votes ...")
+                .execute(&mut *tx).await?;
+            tx.commit().await?;
+        }
+        ScheduleType::Personal => {
+            // Just verify user_id + INSERT
+            sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (...) VALUES (...) RETURNING *"
+            ).fetch_one(pool).await?;
+        }
+    }
+}
+```
+
+### Calendar Query
+
+In Firebase, three separate queries from three locations.
+
+```swift
+// iOS: group schedules -- query by groupId (chunked, max 10 per query)
+for chunk in groupIds.chunked(into: 10) {
+    let snapshot = try await db.collection("promises")
+        .whereField("groupId", in: chunk)
+        .whereField("startAt", isGreaterThan: startDate)
+        .getDocuments()
+}
+
+// iOS: personal events
+let personal = try await db.collection("users").document(uid)
+    .collection("personalEvents")
+    .whereField("startAt", isGreaterThan: startDate)
+    .getDocuments()
+
+// Merge + sort on client
+let all = (groupSchedules + personalSchedules).sorted(by: \.startAt)
+```
+
+In Rust, the server does the merging.
+
+```rust
+// Group + personal in one query
+let schedules = sqlx::query_as::<_, Schedule>(
+    "SELECT * FROM schedules
+     WHERE (schedule_type = 'group' AND group_id = ANY($1))
+        OR (schedule_type = 'personal' AND user_id = $2)
+     AND start_at BETWEEN $3 AND $4
+     ORDER BY start_at"
+)
+.bind(&group_ids).bind(user_id)
+.bind(start).bind(end)
+.fetch_all(pool).await?;
+```
+
+The chunking code for Firestore's 10-item `in` operator limit becomes a single `= ANY($1)` in PostgreSQL. Client-side merging and sorting moves to a server-side `ORDER BY`.
+
+---
+
+## What Disappeared
+
+Things removed in this migration:
+
+- The entire `scheduleSlots` collection + 7 Firestore triggers
+- The split between `promises` and `personalEvents` -- merged into a single `schedules` table
+- Chunking code for Firestore's `in` operator 10-item limit
+- Client-side schedule merging and sorting logic
+- `arrayUnion`/`arrayRemove`-based vote logic -- replaced by SQL UPSERT/DELETE
+- The `votes` subcollection (used for LiveActivity broadcasts) -- to be handled separately later
+- The `badgesCleared` flag -- to be redesigned in the notifications migration (#5)
+
+Things that were added: title length limit (30 chars), description limit (500 chars), end time must be after start time, start time must be in the future. Server-side validations that were missing in Firebase, now added in Rust. A side effect of rewriting: you spot the gaps.
+
+---
+
+## Wrapping Up
+
+Three collections merged into one table. Seven triggers replaced by a single SQL query. The vote state machine wrapped in a transaction. More changes than the group migration, but the same principle: strip away complexity that came from Firestore's constraints, keep only the business rules.
+
+`scheduleSlots` is the poster child. Firestore couldn't do range queries across collections, so I built date-keyed denormalization and maintained it with seven triggers. In PostgreSQL, JOIN + WHERE produces the same result. What seven triggers did, two indexes now handle.
+
+*Next: #5 Notifications and Push -- Direct FCM, Badges, and Per-Group Settings*
+
+*Promiso -- [App Store](https://apps.apple.com/kr/app/id6757733720) -- [GitHub](https://github.com/kswift1/Promiso)*

--- a/docs/blog/04-schedule-api.md
+++ b/docs/blog/04-schedule-api.md
@@ -1,0 +1,344 @@
+# Firebase에서 Rust로 -- 일정 API, 투표 상태 머신과 세 개의 컬렉션
+
+*iOS 앱 서버 마이그레이션기 #4 -- 그룹일정 + 개인일정 + 반복일정을 하나의 테이블로*
+
+---
+
+Firestore에서 일정 관련 데이터는 세 곳에 흩어져 있다.
+
+`promises/{id}` -- 그룹일정. 투표(votes Map), 확정 여부, 장소, 이미지.
+`users/{uid}/personalEvents/{id}` -- 개인일정. 그룹 없이 나만 보는 일정.
+`users/{uid}/scheduleSlots/{YYYY-MM-DD}` -- 충돌 감지용 비정규화. 날짜별로 일정 조각을 복사해둔다.
+
+이 세 가지가 캘린더 화면에서 합쳐져야 한다. 그룹일정과 개인일정을 시간순으로 섞어서 보여주고, 새 일정을 만들 때는 기존 일정과 겹치는지 확인해야 한다. Firestore에서 이걸 하려면 컬렉션 세 개를 각각 쿼리하고, 클라이언트에서 합치고, 정렬한다.
+
+충돌 감지가 특히 고통스러웠다. Firestore는 "이 유저의 모든 일정을 시간 범위로 조회"하는 쿼리를 단일 호출로 지원하지 않는다. 그래서 `scheduleSlots`라는 비정규화 컬렉션을 만들었다. 일정이 생기면 트리거가 해당 날짜의 슬롯 문서에 복사본을 추가한다. 일정이 바뀌면 옛날 슬롯을 지우고 새 슬롯을 넣는다. 삭제되면 슬롯도 지운다. 그룹일정에 3개, 개인일정에 3개, 조회에 1개. 총 7개의 Cloud Functions 트리거가 이 비정규화를 유지한다.
+
+이 트리거들은 실수하기 쉽다. 일정 시간이 바뀌면 옛날 날짜의 슬롯을 지우고 새 날짜에 넣어야 하는데, "이전 startAt"과 "새 startAt"을 둘 다 들고 다녀야 한다. 투표 상태가 바뀌면 수락한 멤버의 슬롯만 추가하거나 제거해야 한다. 반복일정은 규칙 기반이라 슬롯이 없고 조회 시점에 확장한다. 결과적으로 충돌 감지 하나를 위해 데이터 경로가 셋으로 갈라진다.
+
+PostgreSQL로 옮기면서 질문은 하나였다. 이 복잡도 중 얼마가 비즈니스 규칙이고 얼마가 Firestore 제약인가.
+
+---
+
+## 세 컬렉션을 하나의 테이블로
+
+결론부터. `promises` + `personalEvents`를 `schedules` 하나로 합쳤다. `scheduleSlots`는 제거했다.
+
+```sql
+CREATE TABLE schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_type schedule_type NOT NULL,  -- 'group' | 'personal'
+  user_id TEXT NOT NULL REFERENCES users(id),
+
+  title TEXT NOT NULL,
+  emoji TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ,
+  -- ... 공통 필드 ...
+
+  -- 그룹일정 전용 (personal이면 NULL)
+  group_id UUID REFERENCES groups(id),
+  minimum_participants SMALLINT,
+  is_confirmed BOOLEAN,
+  vote_deadline TIMESTAMPTZ,
+
+  -- 개인일정 전용 (group이면 NULL)
+  reminder_minutes_before SMALLINT,
+
+  CONSTRAINT chk_schedule_type_fields CHECK (
+    (schedule_type = 'group'
+      AND group_id IS NOT NULL
+      AND minimum_participants IS NOT NULL)
+    OR
+    (schedule_type = 'personal'
+      AND group_id IS NULL
+      AND minimum_participants IS NULL)
+  )
+);
+```
+
+`schedule_type` enum으로 구분하고, CHECK 제약으로 타입별 필드를 강제한다. 그룹일정인데 `group_id`가 없으면 INSERT 자체가 실패한다. 개인일정인데 `minimum_participants`가 있어도 실패한다. DB가 규칙을 지킨다.
+
+왜 합쳤을까? Firestore에서 분리된 이유를 먼저 보면 -- `promises`는 최상위 컬렉션이고 `personalEvents`는 유저 서브컬렉션이다. 이렇게 나눈 건 보안 규칙 때문이다. Firestore 보안 규칙은 경로 기반이다. `users/{uid}/personalEvents/{id}`로 두면 "본인 문서만 읽기"를 경로 패턴 하나로 끝낼 수 있다. `promises`는 그룹 멤버 전체가 읽어야 하니까 별도 컬렉션에 두고 멤버십 체크를 따로 건다.
+
+PostgreSQL에서는 보안이 경로가 아니라 API 레이어에서 동작한다. 서비스 함수에서 "개인일정이면 `user_id` 일치 확인, 그룹일정이면 그룹 멤버십 확인"을 코드로 처리한다. 분리의 이유가 사라졌고, 합침의 이유가 생겼다. 캘린더에서 한 쿼리로 두 타입을 섞어서 조회할 수 있다.
+
+반복일정(`recurringEvents`)은 별도 테이블 `recurring_schedules`로 유지했다. 이건 Firestore를 따라간 게 아니라, 본질적으로 다른 엔티티이기 때문이다. `schedules`는 "4월 7일 14시에 영화"처럼 구체적인 시점을 저장한다. `recurring_schedules`는 "매주 월수금 19시에 헬스장"이라는 규칙을 저장한다. 필드 구조가 완전히 다르다 -- 하나는 `start_at: TIMESTAMPTZ`이고 다른 하나는 `start_time_hour: SMALLINT` + `start_time_minute: SMALLINT`이다.
+
+---
+
+## scheduleSlots, 사라지다
+
+7개 트리거를 유지하던 `scheduleSlots`는 SQL 한 줄로 대체된다.
+
+```sql
+-- 이 유저의 모든 일정을 시간 범위로 조회 (충돌 감지)
+SELECT s.id, s.title, s.start_at, s.end_at
+FROM schedules s
+JOIN schedule_votes sv ON sv.schedule_id = s.id
+WHERE sv.user_id = $1 AND sv.status = 'accepted'
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL)
+UNION ALL
+SELECT s.id, s.title, s.start_at, s.end_at
+FROM schedules s
+WHERE s.schedule_type = 'personal' AND s.user_id = $1
+  AND s.start_at < $3 AND (s.end_at > $2 OR s.end_at IS NULL);
+```
+
+그룹일정은 `schedule_votes`와 JOIN해서 내가 수락한 것만 가져오고, 개인일정은 `user_id`로 직접 필터한다. 인덱스 두 개면 충분하다.
+
+```sql
+CREATE INDEX idx_schedule_votes_user ON schedule_votes (user_id, status);
+CREATE INDEX idx_schedules_personal_start ON schedules (user_id, start_at)
+  WHERE schedule_type = 'personal';
+```
+
+Firestore에서 비정규화가 필요했던 이유는 "여러 컬렉션을 걸치는 범위 쿼리"가 불가능해서였다. SQL에서는 JOIN + WHERE로 끝난다. 7개 트리거, 슬롯 생성/삭제/갱신 로직, 날짜 키 계산 코드가 전부 사라졌다.
+
+---
+
+## 투표 상태 머신
+
+그룹일정의 핵심은 투표다. 멤버가 일정을 수락하거나 거절하고, 최소 인원이 모이면 확정된다.
+
+Firestore에서 투표는 `votes` Map이다.
+
+```json
+{
+  "votes": {
+    "accepted": ["user_A", "user_B"],
+    "declined": ["user_C"],
+    "until": "2026-04-10T19:00:00+09:00"
+  },
+  "minimumParticipants": 2,
+  "isConfirmed": true
+}
+```
+
+`accepted`와 `declined`는 userId 배열이다. pending은 저장하지 않고 "그룹 멤버 - accepted - declined"로 계산한다. `isConfirmed`는 `accepted.length >= minimumParticipants`의 비정규화 필드다.
+
+이 구조 자체는 Firestore에 맞춤 설계된 것이다. `arrayUnion`/`arrayRemove`로 배열을 Set처럼 쓸 수 있고, 단일 문서 리스너 하나로 모든 투표 변화를 감지할 수 있다.
+
+PostgreSQL에서는 정규화된 테이블로 바꿨다.
+
+```sql
+CREATE TABLE schedule_votes (
+  schedule_id UUID REFERENCES schedules(id) ON DELETE CASCADE,
+  user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+  status vote_status NOT NULL,  -- 'accepted' | 'declined'
+  responded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (schedule_id, user_id)
+);
+```
+
+pending은 여전히 저장하지 않는다. `group_members`에 있는데 `schedule_votes`에 없으면 pending이다. 이 설계는 Firebase와 같은 원칙이다.
+
+투표 응답 로직은 트랜잭션 안에서 동작한다.
+
+```rust
+let mut tx = pool.begin().await?;
+
+match status {
+    "accepted" | "declined" => {
+        // UPSERT -- 이미 투표했으면 상태만 바꾼다
+        sqlx::query(
+            "INSERT INTO schedule_votes (schedule_id, user_id, status)
+             VALUES ($1, $2, $3::vote_status)
+             ON CONFLICT (schedule_id, user_id)
+             DO UPDATE SET status = $3::vote_status, responded_at = NOW()"
+        )
+        .bind(schedule_id).bind(user_id).bind(status)
+        .execute(&mut *tx).await?;
+    }
+    "pending" => {
+        // 투표 취소 = row 자체를 삭제
+        sqlx::query(
+            "DELETE FROM schedule_votes
+             WHERE schedule_id = $1 AND user_id = $2"
+        )
+        .bind(schedule_id).bind(user_id)
+        .execute(&mut *tx).await?;
+    }
+}
+
+// is_confirmed 재계산 -- 같은 트랜잭션에서
+let accepted_count: i64 = sqlx::query_scalar(
+    "SELECT COUNT(*) FROM schedule_votes
+     WHERE schedule_id = $1 AND status = 'accepted'"
+)
+.bind(schedule_id)
+.fetch_one(&mut *tx).await?;
+
+let new_confirmed = accepted_count >= minimum_participants as i64;
+sqlx::query("UPDATE schedules SET is_confirmed = $1 WHERE id = $2")
+    .bind(new_confirmed).bind(schedule_id)
+    .execute(&mut *tx).await?;
+
+tx.commit().await?;
+```
+
+Firestore에서도 `runTransaction` 안에서 같은 일을 했다. 차이는 `arrayUnion`/`arrayRemove` 대신 `INSERT ON CONFLICT`와 `DELETE`를 쓴다는 것, 그리고 `is_confirmed` 재계산이 배열 길이가 아니라 `COUNT(*)` 쿼리라는 것이다. 비즈니스 규칙은 같고 표현 방식만 다르다.
+
+`is_confirmed`를 별도 컬럼으로 유지한 이유는 쿼리 때문이다. 캘린더 동기화에서 "확정된 미래 일정"만 가져와야 하는데, `WHERE is_confirmed = TRUE AND start_at >= NOW()` 한 줄이면 된다. 매번 votes를 세서 판단하는 것보다 인덱스가 명확하다.
+
+---
+
+## 반복일정의 frequency별 상호배타
+
+반복일정 스키마에서 재미있었던 부분은 CHECK 제약이다.
+
+```sql
+CONSTRAINT chk_recurrence_fields CHECK (
+  (frequency = 'daily'
+    AND days_of_week IS NULL
+    AND day_of_month IS NULL)
+  OR
+  (frequency = 'weekly'
+    AND days_of_week IS NOT NULL
+    AND array_length(days_of_week, 1) > 0
+    AND day_of_month IS NULL)
+  OR
+  (frequency = 'monthly'
+    AND days_of_week IS NULL
+    AND day_of_month IS NOT NULL
+    AND day_of_month BETWEEN 1 AND 31)
+)
+```
+
+daily인데 `days_of_week`가 있으면? INSERT 실패. weekly인데 `days_of_week`가 빈 배열이면? INSERT 실패. monthly인데 `day_of_month`가 없으면? INSERT 실패. 서비스 코드가 검증을 빼먹어도 DB가 잡아준다.
+
+Swift에서 이런 상호배타를 표현하려면 associated value가 있는 enum을 쓴다.
+
+```swift
+enum Recurrence {
+    case daily
+    case weekly(daysOfWeek: [Int])
+    case monthly(dayOfMonth: Int)
+}
+```
+
+타입 시스템이 "weekly이면 반드시 daysOfWeek가 있다"를 컴파일 타임에 보장한다. SQL의 CHECK 제약은 같은 보장을 런타임에, DB 레벨에서 제공한다. 계층이 다를 뿐 목적은 같다.
+
+---
+
+## 코드: Before/After
+
+### 일정 생성
+
+Firebase에서는 그룹일정과 개인일정이 완전히 다른 경로를 탄다.
+
+```typescript
+// Firebase: 그룹일정 -- Cloud Function
+export const createPromise = onCall(async (request) => {
+  const promiseRef = promisesCollection.doc();
+  await promiseRef.set({
+    title, groupId, hostId: userId,
+    votes: { accepted: [userId], declined: [], until: startAt },
+    isConfirmed: initialAccepted.length >= minimumParticipants,
+    // ... 20줄 더 ...
+  });
+  return { promiseId: promiseRef.id };
+});
+
+// Firebase: 개인일정 -- 클라이언트가 Firestore 직접 쓰기
+db.collection("users").document(userId)
+  .collection("personalEvents").addDocument(data: [...])
+```
+
+Rust에서는 `schedule_type`으로 분기하는 하나의 함수다.
+
+```rust
+pub async fn create_schedule(
+    pool: &PgPool, user_id: &str, req: CreateScheduleRequest
+) -> Result<CreateScheduleResponse, AppError> {
+    match req.schedule_type {
+        ScheduleType::Group => {
+            // 그룹 멤버십 확인 + INSERT + 호스트 자동 투표
+            let mut tx = pool.begin().await?;
+            let schedule = sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (...) VALUES (...) RETURNING *"
+            ).fetch_one(&mut *tx).await?;
+
+            // 호스트 자동 accepted
+            sqlx::query("INSERT INTO schedule_votes ...")
+                .execute(&mut *tx).await?;
+            tx.commit().await?;
+        }
+        ScheduleType::Personal => {
+            // user_id만 확인 + INSERT
+            sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (...) VALUES (...) RETURNING *"
+            ).fetch_one(pool).await?;
+        }
+    }
+}
+```
+
+### 캘린더 조회
+
+Firebase에서는 세 곳을 따로 쿼리한다.
+
+```swift
+// iOS: 그룹일정 -- groupId별로 쿼리 (최대 10개씩 청크)
+for chunk in groupIds.chunked(into: 10) {
+    let snapshot = try await db.collection("promises")
+        .whereField("groupId", in: chunk)
+        .whereField("startAt", isGreaterThan: startDate)
+        .getDocuments()
+}
+
+// iOS: 개인일정
+let personal = try await db.collection("users").document(uid)
+    .collection("personalEvents")
+    .whereField("startAt", isGreaterThan: startDate)
+    .getDocuments()
+
+// 클라이언트에서 합치기 + 정렬
+let all = (groupSchedules + personalSchedules).sorted(by: \.startAt)
+```
+
+Rust에서는 서버가 합쳐서 준다.
+
+```rust
+// 그룹 + 개인 한 번에
+let schedules = sqlx::query_as::<_, Schedule>(
+    "SELECT * FROM schedules
+     WHERE (schedule_type = 'group' AND group_id = ANY($1))
+        OR (schedule_type = 'personal' AND user_id = $2)
+     AND start_at BETWEEN $3 AND $4
+     ORDER BY start_at"
+)
+.bind(&group_ids).bind(user_id)
+.bind(start).bind(end)
+.fetch_all(pool).await?;
+```
+
+Firestore의 `in` 연산자 10개 제한으로 청크를 나누던 코드가 PostgreSQL의 `= ANY($1)` 한 줄로 줄었다. 클라이언트에서 합치고 정렬하던 로직이 서버 `ORDER BY`로 이동했다.
+
+---
+
+## 사라진 것들
+
+이번 마이그레이션에서 제거된 것들.
+
+- `scheduleSlots` 컬렉션 전체 + 7개 Firestore 트리거
+- `promises`와 `personalEvents` 분리 -- 단일 `schedules` 테이블로 통합
+- Firestore `in` 연산자 10개 제한 대응 청크 코드
+- 클라이언트 측 일정 합치기/정렬 로직
+- `arrayUnion`/`arrayRemove` 기반 투표 로직 -- SQL UPSERT/DELETE로 대체
+- `votes` 서브컬렉션 (LiveActivity 브로드캐스트용) -- 향후 별도 처리
+- `badgesCleared` 플래그 -- 알림 마이그레이션(#5)에서 재설계
+
+새로 생긴 것도 있다. 제목 30자 제한, 설명 500자 제한, 종료 시간 > 시작 시간 검증, 시작 시간 미래 검증. Firebase 때 빠져 있던 서버 측 검증을 Rust에서 추가했다. 이건 마이그레이션의 부수 효과다. 코드를 다시 쓰면서 누락된 검증이 보인다.
+
+---
+
+## 마무리
+
+세 컬렉션을 하나의 테이블로 합치고, 7개 트리거를 SQL 한 줄로 대체하고, 투표 상태 머신을 트랜잭션으로 감쌌다. 변경량은 그룹 때보다 많았지만 원칙은 같다. Firestore 제약에서 나온 복잡도를 걷어내고, 비즈니스 규칙만 남긴다.
+
+`scheduleSlots`가 대표적이다. Firestore에서는 "여러 컬렉션을 걸치는 범위 쿼리"가 안 되니까 날짜별 비정규화를 만들고, 7개 트리거로 유지했다. PostgreSQL에서는 JOIN + WHERE로 같은 결과를 얻는다. 트리거 7개가 하던 일을 인덱스 2개가 대신한다.
+
+*다음 글: #5 알림과 푸시 -- FCM 직접 발송 + 배지 + 그룹별 설정*
+
+*Promiso -- [App Store](https://apps.apple.com/kr/app/id6757733720) · [GitHub](https://github.com/kswift1/Promiso)*

--- a/infra/rust-backend/Cargo.lock
+++ b/infra/rust-backend/Cargo.lock
@@ -195,6 +195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1294,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1399,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "chrono-tz",
  "dotenvy",
  "http-body-util",
  "jsonwebtoken",
@@ -1796,6 +1825,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"

--- a/infra/rust-backend/Cargo.toml
+++ b/infra/rust-backend/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Utilities
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 dotenvy = "0.15"
 rand = "0.10"
 

--- a/infra/rust-backend/migrations/005_schedules.sql
+++ b/infra/rust-backend/migrations/005_schedules.sql
@@ -1,0 +1,165 @@
+-- 005_schedules.sql
+-- 일정 도메인: 그룹일정 + 개인일정 통합 테이블, 투표, 반복일정
+
+-- ============================================================
+-- 타입 정의
+-- ============================================================
+CREATE TYPE schedule_type AS ENUM ('group', 'personal');
+CREATE TYPE vote_status   AS ENUM ('accepted', 'declined');
+CREATE TYPE recurrence_frequency AS ENUM ('daily', 'weekly', 'monthly');
+
+-- ============================================================
+-- schedules (그룹일정 + 개인일정 통합)
+-- ============================================================
+CREATE TABLE schedules (
+  id                            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_type                 schedule_type NOT NULL,
+  user_id                       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                                -- personal: 소유자, group: 호스트
+
+  -- 공통 필드
+  title                         TEXT NOT NULL,
+  emoji                         TEXT,
+  description                   TEXT,
+  description_blocks            JSONB,
+  start_at                      TIMESTAMPTZ NOT NULL,
+  end_at                        TIMESTAMPTZ,
+  location_name                 TEXT,
+  location_address              TEXT,
+  location_latitude             DOUBLE PRECISION,
+  location_longitude            DOUBLE PRECISION,
+  created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- 그룹일정 전용 (personal이면 NULL)
+  group_id                      UUID REFERENCES groups(id) ON DELETE CASCADE,
+  minimum_participants          SMALLINT,
+  is_confirmed                  BOOLEAN,
+  vote_deadline                 TIMESTAMPTZ,
+  tracking_start_minutes_before SMALLINT,
+  image_urls                    TEXT[],
+
+  -- 개인일정 전용 (group이면 NULL)
+  reminder_minutes_before       SMALLINT,
+
+  -- 제약 조건
+  CONSTRAINT chk_title_not_empty   CHECK (char_length(trim(title)) > 0),
+  CONSTRAINT chk_title_max_len     CHECK (char_length(title) <= 30),
+  CONSTRAINT chk_desc_max_len      CHECK (description IS NULL OR char_length(description) <= 500),
+  CONSTRAINT chk_end_after_start   CHECK (end_at IS NULL OR end_at > start_at),
+  CONSTRAINT chk_min_participants  CHECK (minimum_participants IS NULL OR minimum_participants >= 1),
+  CONSTRAINT chk_desc_blocks_max   CHECK (description_blocks IS NULL OR jsonb_array_length(description_blocks) <= 20),
+  CONSTRAINT chk_image_urls_max    CHECK (image_urls IS NULL OR array_length(image_urls, 1) <= 3),
+
+  -- 타입별 필드 정합성
+  CONSTRAINT chk_schedule_type_fields CHECK (
+    (schedule_type = 'group'
+      AND group_id IS NOT NULL
+      AND minimum_participants IS NOT NULL
+      AND is_confirmed IS NOT NULL
+      AND vote_deadline IS NOT NULL)
+    OR
+    (schedule_type = 'personal'
+      AND group_id IS NULL
+      AND minimum_participants IS NULL
+      AND is_confirmed IS NULL
+      AND vote_deadline IS NULL
+      AND tracking_start_minutes_before IS NULL
+      AND image_urls IS NULL)
+  )
+);
+
+-- ============================================================
+-- schedule_votes (그룹일정 투표)
+-- ============================================================
+CREATE TABLE schedule_votes (
+  schedule_id  UUID NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
+  user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  status       vote_status NOT NULL,
+  responded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (schedule_id, user_id)
+);
+
+-- ============================================================
+-- recurring_schedules (반복일정 규칙)
+-- ============================================================
+CREATE TABLE recurring_schedules (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title                   TEXT NOT NULL,
+  emoji                   TEXT,
+  description             TEXT,
+  start_time_hour         SMALLINT NOT NULL,
+  start_time_minute       SMALLINT NOT NULL,
+  end_time_hour           SMALLINT,
+  end_time_minute         SMALLINT,
+  location_name           TEXT,
+  location_address        TEXT,
+  location_latitude       DOUBLE PRECISION,
+  location_longitude      DOUBLE PRECISION,
+  reminder_minutes_before SMALLINT,
+  frequency               recurrence_frequency NOT NULL,
+  days_of_week            SMALLINT[],
+  day_of_month            SMALLINT,
+  series_start_date       DATE NOT NULL,
+  series_end_date         DATE,
+  excluded_dates          DATE[],
+  overrides               JSONB,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT chk_rec_title_not_empty    CHECK (char_length(trim(title)) > 0),
+  CONSTRAINT chk_start_hour             CHECK (start_time_hour BETWEEN 0 AND 23),
+  CONSTRAINT chk_start_minute           CHECK (start_time_minute BETWEEN 0 AND 59),
+  CONSTRAINT chk_end_hour               CHECK (end_time_hour IS NULL OR end_time_hour BETWEEN 0 AND 23),
+  CONSTRAINT chk_end_minute             CHECK (end_time_minute IS NULL OR end_time_minute BETWEEN 0 AND 59),
+  CONSTRAINT chk_end_time_pair          CHECK (
+    (end_time_hour IS NULL AND end_time_minute IS NULL) OR
+    (end_time_hour IS NOT NULL AND end_time_minute IS NOT NULL)
+  ),
+  -- frequency별 상호배타 필드 정합성
+  CONSTRAINT chk_recurrence_fields CHECK (
+    (frequency = 'daily'
+      AND days_of_week IS NULL
+      AND day_of_month IS NULL)
+    OR
+    (frequency = 'weekly'
+      AND days_of_week IS NOT NULL
+      AND array_length(days_of_week, 1) > 0
+      AND day_of_month IS NULL)
+    OR
+    (frequency = 'monthly'
+      AND days_of_week IS NULL
+      AND day_of_month IS NOT NULL
+      AND day_of_month BETWEEN 1 AND 31)
+  ),
+  CONSTRAINT chk_series_end_after_start CHECK (series_end_date IS NULL OR series_end_date >= series_start_date)
+);
+
+-- ============================================================
+-- 인덱스
+-- ============================================================
+
+-- 그룹일정 시간순 조회
+CREATE INDEX idx_schedules_group_start
+  ON schedules (group_id, start_at)
+  WHERE schedule_type = 'group';
+
+-- 개인일정 시간순 조회
+CREATE INDEX idx_schedules_personal_start
+  ON schedules (user_id, start_at)
+  WHERE schedule_type = 'personal';
+
+-- 캘린더 동기화 (확정된 미래 일정)
+CREATE INDEX idx_schedules_confirmed
+  ON schedules (start_at)
+  WHERE schedule_type = 'group' AND is_confirmed = TRUE;
+
+-- 유저의 투표 상태별 일정 조회
+CREATE INDEX idx_schedule_votes_user
+  ON schedule_votes (user_id, status);
+
+-- 유저의 반복일정 조회
+CREATE INDEX idx_recurring_user
+  ON recurring_schedules (user_id);

--- a/infra/rust-backend/src/config/mod.rs
+++ b/infra/rust-backend/src/config/mod.rs
@@ -9,11 +9,10 @@ impl Config {
     pub fn from_env() -> Self {
         dotenvy::dotenv().ok();
 
-        let database_url = std::env::var("DATABASE_URL")
-            .expect("DATABASE_URL must be set");
+        let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
-        let database_pool_url = std::env::var("DATABASE_POOL_URL")
-            .unwrap_or_else(|_| database_url.clone());
+        let database_pool_url =
+            std::env::var("DATABASE_POOL_URL").unwrap_or_else(|_| database_url.clone());
 
         Self {
             database_url,

--- a/infra/rust-backend/src/errors/mod.rs
+++ b/infra/rust-backend/src/errors/mod.rs
@@ -30,15 +30,27 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code, message) = match &self {
-            AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, "unauthenticated", msg.as_str()),
+            AppError::Unauthorized(msg) => {
+                (StatusCode::UNAUTHORIZED, "unauthenticated", msg.as_str())
+            }
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, "permission-denied", msg.as_str()),
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, "not-found", msg.as_str()),
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "invalid-argument", msg.as_str()),
+            AppError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, "invalid-argument", msg.as_str())
+            }
             AppError::Conflict(msg) => (StatusCode::CONFLICT, "already-exists", msg.as_str()),
-            AppError::PreconditionFailed(msg) => (StatusCode::PRECONDITION_FAILED, "failed-precondition", msg.as_str()),
+            AppError::PreconditionFailed(msg) => (
+                StatusCode::PRECONDITION_FAILED,
+                "failed-precondition",
+                msg.as_str(),
+            ),
             AppError::Internal(msg) => {
                 tracing::error!("Internal error: {}", msg);
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal", "Internal server error")
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal",
+                    "Internal server error",
+                )
             }
         };
 

--- a/infra/rust-backend/src/main.rs
+++ b/infra/rust-backend/src/main.rs
@@ -35,6 +35,8 @@ async fn main() {
     let addr = format!("[::]:{}", config.port);
     tracing::info!("Starting server on {}", addr);
 
-    let listener = TcpListener::bind(&addr).await.expect("Failed to bind address");
+    let listener = TcpListener::bind(&addr)
+        .await
+        .expect("Failed to bind address");
     axum::serve(listener, app).await.expect("Server error");
 }

--- a/infra/rust-backend/src/middleware/auth.rs
+++ b/infra/rust-backend/src/middleware/auth.rs
@@ -97,8 +97,7 @@ impl FirebaseAuth {
         {
             let mut cached = self.cached_keys.write().await;
             cached.keys = keys.clone();
-            cached.expires_at =
-                std::time::Instant::now() + std::time::Duration::from_secs(max_age);
+            cached.expires_at = std::time::Instant::now() + std::time::Duration::from_secs(max_age);
         }
 
         Ok(keys)

--- a/infra/rust-backend/src/models/group.rs
+++ b/infra/rust-backend/src/models/group.rs
@@ -1,11 +1,13 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use serde::de::Deserializer;
+use serde::{Deserialize, Serialize};
 use sqlx::types::Uuid;
 
 /// JSON에서 필드 없음 → `None`, `"field": null` → `Some(None)`, `"field": "val"` → `Some(Some("val"))`
 /// `#[serde(default, deserialize_with = "deserialize_optional_field")]` 와 함께 사용
-pub fn deserialize_optional_field<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
+pub fn deserialize_optional_field<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/infra/rust-backend/src/models/mod.rs
+++ b/infra/rust-backend/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod group;
+pub mod schedule;
 pub mod user;

--- a/infra/rust-backend/src/models/schedule.rs
+++ b/infra/rust-backend/src/models/schedule.rs
@@ -1,0 +1,311 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ============================================================
+// DB 열거형 (PostgreSQL 타입 매핑)
+// ============================================================
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "schedule_type", rename_all = "lowercase")]
+pub enum ScheduleType {
+    Group,
+    Personal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "vote_status", rename_all = "lowercase")]
+pub enum VoteStatus {
+    Accepted,
+    Declined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
+#[sqlx(type_name = "recurrence_frequency", rename_all = "lowercase")]
+pub enum RecurrenceFrequency {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+// ============================================================
+// DB 모델
+// ============================================================
+
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct Schedule {
+    pub id: Uuid,
+    pub schedule_type: ScheduleType,
+    pub user_id: String,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub description: Option<String>,
+    pub description_blocks: Option<serde_json::Value>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub location_name: Option<String>,
+    pub location_address: Option<String>,
+    pub location_latitude: Option<f64>,
+    pub location_longitude: Option<f64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    // 그룹일정 전용
+    pub group_id: Option<Uuid>,
+    pub minimum_participants: Option<i16>,
+    pub is_confirmed: Option<bool>,
+    pub vote_deadline: Option<DateTime<Utc>>,
+    pub tracking_start_minutes_before: Option<i16>,
+    pub image_urls: Option<Vec<String>>,
+    // 개인일정 전용
+    pub reminder_minutes_before: Option<i16>,
+}
+
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct ScheduleVote {
+    pub schedule_id: Uuid,
+    pub user_id: String,
+    pub status: VoteStatus,
+    pub responded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct RecurringSchedule {
+    pub id: Uuid,
+    pub user_id: String,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub description: Option<String>,
+    pub start_time_hour: i16,
+    pub start_time_minute: i16,
+    pub end_time_hour: Option<i16>,
+    pub end_time_minute: Option<i16>,
+    pub location_name: Option<String>,
+    pub location_address: Option<String>,
+    pub location_latitude: Option<f64>,
+    pub location_longitude: Option<f64>,
+    pub reminder_minutes_before: Option<i16>,
+    pub frequency: RecurrenceFrequency,
+    pub days_of_week: Option<Vec<i16>>,
+    pub day_of_month: Option<i16>,
+    pub series_start_date: NaiveDate,
+    pub series_end_date: Option<NaiveDate>,
+    pub excluded_dates: Option<Vec<NaiveDate>>,
+    pub overrides: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ============================================================
+// 요청 DTO
+// ============================================================
+
+#[derive(Debug, Deserialize)]
+pub struct CreateScheduleRequest {
+    pub schedule_type: ScheduleType,
+    pub group_id: Option<Uuid>,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub description: Option<String>,
+    pub description_blocks: Option<serde_json::Value>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub location: Option<LocationRequest>,
+    pub minimum_participants: Option<i16>,
+    pub tracking_start_minutes_before: Option<i16>,
+    pub image_urls: Option<Vec<String>>,
+    pub reminder_minutes_before: Option<i16>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LocationRequest {
+    pub name: String,
+    pub address: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateScheduleRequest {
+    // Option<Option<T>> 패턴:
+    //   None          -> 변경 없음 (JSON에서 필드 생략)
+    //   Some(None)    -> 삭제 (JSON에서 "field": null)
+    //   Some(Some(v)) -> 값 변경 (JSON에서 "field": "value")
+    pub title: Option<String>,
+    pub emoji: Option<Option<String>>,
+    pub description: Option<Option<String>>,
+    pub description_blocks: Option<Option<serde_json::Value>>,
+    pub start_at: Option<DateTime<Utc>>,
+    pub end_at: Option<Option<DateTime<Utc>>>,
+    pub location: Option<Option<LocationRequest>>,
+    pub minimum_participants: Option<i16>,
+    pub tracking_start_minutes_before: Option<Option<i16>>,
+    pub image_urls: Option<Option<Vec<String>>>,
+    pub reminder_minutes_before: Option<Option<i16>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RespondScheduleRequest {
+    pub status: String, // "accepted" | "declined" | "pending"
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckConflictsRequest {
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub min_gap_minutes: Option<i32>,
+    pub exclude_ids: Option<Vec<Uuid>>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRecurringScheduleRequest {
+    pub title: String,
+    pub emoji: Option<String>,
+    pub description: Option<String>,
+    pub start_time: TimeComponents,
+    pub end_time: Option<TimeComponents>,
+    pub location: Option<LocationRequest>,
+    pub reminder_minutes_before: Option<i16>,
+    pub frequency: RecurrenceFrequency,
+    pub days_of_week: Option<Vec<i16>>,
+    pub day_of_month: Option<i16>,
+    pub series_start_date: NaiveDate,
+    pub series_end_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TimeComponents {
+    pub hour: i16,
+    pub minute: i16,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateRecurringScheduleRequest {
+    pub title: Option<String>,
+    pub emoji: Option<Option<String>>,
+    pub description: Option<Option<String>>,
+    pub start_time: Option<TimeComponents>,
+    pub end_time: Option<Option<TimeComponents>>,
+    pub location: Option<Option<LocationRequest>>,
+    pub reminder_minutes_before: Option<Option<i16>>,
+    pub frequency: Option<RecurrenceFrequency>,
+    pub days_of_week: Option<Option<Vec<i16>>>,
+    pub day_of_month: Option<Option<i16>>,
+    pub series_start_date: Option<NaiveDate>,
+    pub series_end_date: Option<Option<NaiveDate>>,
+    pub excluded_dates: Option<Vec<NaiveDate>>,
+    pub overrides: Option<serde_json::Value>,
+}
+
+// 쿼리 파라미터
+#[derive(Debug, Deserialize)]
+pub struct GroupScheduleQuery {
+    pub status: Option<String>, // "active" | "past"
+    pub limit: Option<i64>,
+    pub cursor: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CalendarQuery {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub accepted_only: Option<bool>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HomeQuery {
+    pub limit: Option<i64>,
+}
+
+// ============================================================
+// 응답 DTO
+// ============================================================
+
+#[derive(Debug, Serialize)]
+pub struct CreateScheduleResponse {
+    pub schedule_id: Uuid,
+    pub title: String,
+    pub group_id: Option<Uuid>,
+    pub start_at: DateTime<Utc>,
+    pub is_confirmed: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScheduleResponse {
+    pub id: Uuid,
+    pub schedule_type: ScheduleType,
+    pub user_id: String,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub description: Option<String>,
+    pub description_blocks: Option<serde_json::Value>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub location: Option<LocationResponse>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    // 그룹일정 전용
+    pub group_id: Option<Uuid>,
+    pub host_id: Option<String>,
+    pub minimum_participants: Option<i16>,
+    pub is_confirmed: Option<bool>,
+    pub vote_deadline: Option<DateTime<Utc>>,
+    pub tracking_start_minutes_before: Option<i16>,
+    pub image_urls: Option<Vec<String>>,
+    pub votes: Option<VotesResponse>,
+    // 개인일정 전용
+    pub reminder_minutes_before: Option<i16>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LocationResponse {
+    pub name: String,
+    pub address: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VotesResponse {
+    pub accepted: Vec<String>,
+    pub declined: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RespondScheduleResponse {
+    pub schedule_id: Uuid,
+    pub status: String,
+    pub is_confirmed: bool,
+    pub confirmed_schedule: Option<CalendarSyncSchedule>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CalendarSyncSchedule {
+    pub id: Uuid,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub location: Option<String>,
+    pub group_id: Uuid,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScheduleConflict {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub conflict_type: String,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub overlap_minutes: i64,
+    pub gap_minutes: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateRecurringScheduleResponse {
+    pub id: Uuid,
+    pub created_at: DateTime<Utc>,
+}

--- a/infra/rust-backend/src/models/schedule.rs
+++ b/infra/rust-backend/src/models/schedule.rs
@@ -305,7 +305,49 @@ pub struct ScheduleConflict {
 }
 
 #[derive(Debug, Serialize)]
+pub struct PaginatedScheduleResponse {
+    pub data: Vec<ScheduleResponse>,
+    pub cursor: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CalendarResponse {
+    pub schedules: Vec<ScheduleResponse>,
+    pub recurring_instances: Vec<RecurringInstance>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecurringInstance {
+    pub recurring_schedule_id: Uuid,
+    pub title: String,
+    pub emoji: Option<String>,
+    pub date: NaiveDate,
+    pub start_time: TimeComponents,
+    pub end_time: Option<TimeComponents>,
+    pub location: Option<LocationResponse>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct CreateRecurringScheduleResponse {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExtractScheduleRequest {
+    pub text: Option<String>,
+    pub image_base64: Option<String>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExtractScheduleResponse {
+    pub title: Option<String>,
+    pub emoji: Option<String>,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+    pub location: Option<String>,
+    pub address: Option<String>,
+    pub description: Option<String>,
+    pub description_blocks: Option<serde_json::Value>,
 }

--- a/infra/rust-backend/src/routes/mod.rs
+++ b/infra/rust-backend/src/routes/mod.rs
@@ -1,5 +1,6 @@
 mod groups;
 mod health;
+mod schedules;
 mod users;
 
 use axum::middleware;
@@ -15,12 +16,13 @@ pub fn create_router(pool: PgPool, config: &Config) -> Router {
     // 인증 필요한 라우트
     let authenticated_routes = users::router()
         .merge(groups::router())
+        .merge(schedules::router())
         .layer(middleware::from_fn(require_auth));
 
     Router::new()
-        .merge(health::router())             // /health — 인증 불필요
-        .merge(groups::public_router())      // /api/v1/groups/preview — 인증 불필요
-        .merge(authenticated_routes)         // /api/v1/users/*, /api/v1/groups/* — 인증 필요
+        .merge(health::router()) // /health — 인증 불필요
+        .merge(groups::public_router()) // /api/v1/groups/preview — 인증 불필요
+        .merge(authenticated_routes) // /api/v1/users/*, /api/v1/groups/* — 인증 필요
         .layer(axum::Extension(firebase_auth))
         .with_state(pool)
 }

--- a/infra/rust-backend/src/routes/schedules.rs
+++ b/infra/rust-backend/src/routes/schedules.rs
@@ -1,0 +1,181 @@
+use axum::extract::{Path, Query, State};
+use axum::routing::{delete, get, patch, post};
+use axum::{Extension, Json, Router};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::errors::AppError;
+use crate::middleware::auth::Claims;
+use crate::models::schedule::*;
+use crate::response::ApiResponse;
+use crate::services::schedule_service;
+
+pub fn router() -> Router<PgPool> {
+    let schedule_routes = Router::new()
+        .route("/", post(create_schedule))
+        .route("/home", get(get_home_schedules))
+        .route("/calendar", get(get_calendar_schedules))
+        .route("/calendar-sync", get(get_calendar_sync))
+        .route("/check-conflicts", post(check_conflicts))
+        .route("/extract", post(extract_schedule))
+        .route("/{id}", get(get_schedule))
+        .route("/{id}", patch(update_schedule))
+        .route("/{id}", delete(delete_schedule))
+        .route("/{id}/respond", post(respond_schedule));
+
+    let recurring_routes = Router::new()
+        .route("/", post(create_recurring_schedule))
+        .route("/", get(get_recurring_schedules))
+        .route("/{id}", patch(update_recurring_schedule))
+        .route("/{id}", delete(delete_recurring_schedule));
+
+    // Group-nested schedule routes
+    let group_schedule_routes = Router::new().route("/", get(get_group_schedules));
+
+    Router::new()
+        .nest("/api/v1/schedules", schedule_routes)
+        .nest("/api/v1/recurring-schedules", recurring_routes)
+        .nest(
+            "/api/v1/groups/{group_id}/schedules",
+            group_schedule_routes,
+        )
+}
+
+async fn create_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(req): Json<CreateScheduleRequest>,
+) -> Result<ApiResponse<CreateScheduleResponse>, AppError> {
+    let result = schedule_service::create_schedule(&pool, &claims.uid, req).await?;
+    ApiResponse::created(result)
+}
+
+async fn get_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+) -> Result<ApiResponse<ScheduleResponse>, AppError> {
+    let result = schedule_service::get_schedule(&pool, &claims.uid, id).await?;
+    ApiResponse::ok(result)
+}
+
+async fn update_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateScheduleRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    schedule_service::update_schedule(&pool, &claims.uid, id, req).await?;
+    ApiResponse::ok(serde_json::json!({"success": true}))
+}
+
+async fn delete_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    schedule_service::delete_schedule(&pool, &claims.uid, id).await?;
+    ApiResponse::ok(serde_json::json!({"success": true}))
+}
+
+async fn respond_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<RespondScheduleRequest>,
+) -> Result<ApiResponse<RespondScheduleResponse>, AppError> {
+    let result = schedule_service::respond_schedule(&pool, &claims.uid, id, req).await?;
+    ApiResponse::ok(result)
+}
+
+async fn get_group_schedules(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(group_id): Path<Uuid>,
+    Query(query): Query<GroupScheduleQuery>,
+) -> Result<ApiResponse<PaginatedScheduleResponse>, AppError> {
+    let result =
+        schedule_service::get_group_schedules(&pool, &claims.uid, group_id, query).await?;
+    ApiResponse::ok(result)
+}
+
+async fn get_home_schedules(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Query(query): Query<HomeQuery>,
+) -> Result<ApiResponse<Vec<ScheduleResponse>>, AppError> {
+    let result = schedule_service::get_home_schedules(&pool, &claims.uid, query).await?;
+    ApiResponse::ok(result)
+}
+
+async fn get_calendar_schedules(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Query(query): Query<CalendarQuery>,
+) -> Result<ApiResponse<CalendarResponse>, AppError> {
+    let result = schedule_service::get_calendar_schedules(&pool, &claims.uid, query).await?;
+    ApiResponse::ok(result)
+}
+
+async fn get_calendar_sync(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+) -> Result<ApiResponse<Vec<CalendarSyncSchedule>>, AppError> {
+    let result = schedule_service::get_calendar_sync(&pool, &claims.uid).await?;
+    ApiResponse::ok(result)
+}
+
+async fn check_conflicts(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(req): Json<CheckConflictsRequest>,
+) -> Result<ApiResponse<Vec<ScheduleConflict>>, AppError> {
+    let result = schedule_service::check_conflicts(&pool, &claims.uid, req).await?;
+    ApiResponse::ok(result)
+}
+
+async fn extract_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(req): Json<ExtractScheduleRequest>,
+) -> Result<ApiResponse<ExtractScheduleResponse>, AppError> {
+    let result = schedule_service::extract_schedule(&pool, &claims.uid, req).await?;
+    ApiResponse::ok(result)
+}
+
+async fn create_recurring_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Json(req): Json<CreateRecurringScheduleRequest>,
+) -> Result<ApiResponse<CreateRecurringScheduleResponse>, AppError> {
+    let result =
+        schedule_service::create_recurring_schedule(&pool, &claims.uid, req).await?;
+    ApiResponse::created(result)
+}
+
+async fn get_recurring_schedules(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+) -> Result<ApiResponse<Vec<RecurringSchedule>>, AppError> {
+    let result = schedule_service::get_recurring_schedules(&pool, &claims.uid).await?;
+    ApiResponse::ok(result)
+}
+
+async fn update_recurring_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateRecurringScheduleRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    schedule_service::update_recurring_schedule(&pool, &claims.uid, id, req).await?;
+    ApiResponse::ok(serde_json::json!({"success": true}))
+}
+
+async fn delete_recurring_schedule(
+    State(pool): State<PgPool>,
+    Extension(claims): Extension<Claims>,
+    Path(id): Path<Uuid>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    schedule_service::delete_recurring_schedule(&pool, &claims.uid, id).await?;
+    ApiResponse::ok(serde_json::json!({"success": true}))
+}

--- a/infra/rust-backend/src/routes/users.rs
+++ b/infra/rust-backend/src/routes/users.rs
@@ -15,7 +15,10 @@ pub fn router() -> Router<PgPool> {
         .route("/api/v1/users", post(create_user))
         .route("/api/v1/users/me", get(get_my_profile).patch(update_user))
         .route("/api/v1/users/me/profile-image", post(upload_profile_image))
-        .route("/api/v1/users/nickname-check", get(check_nickname_available))
+        .route(
+            "/api/v1/users/nickname-check",
+            get(check_nickname_available),
+        )
         .route("/api/v1/users/batch", post(batch_get_users))
         .route("/api/v1/users/{id}", get(get_user_public))
 }
@@ -74,8 +77,7 @@ async fn check_nickname_available(
     State(pool): State<PgPool>,
     Query(query): Query<NicknameQuery>,
 ) -> Result<ApiResponse<NicknameCheckResponse>, AppError> {
-    let response =
-        user_service::check_nickname_available(&pool, &claims.uid, &query.q).await?;
+    let response = user_service::check_nickname_available(&pool, &claims.uid, &query.q).await?;
     ApiResponse::ok(response)
 }
 

--- a/infra/rust-backend/src/services/group_service.rs
+++ b/infra/rust-backend/src/services/group_service.rs
@@ -49,10 +49,8 @@ const ROLE_ADMIN: &str = "admin";
 const ROLE_MEMBER: &str = "member";
 
 const GROUP_COLOR_PALETTE: &[&str] = &[
-    "#FF3B30", "#FF6F61", "#FF9500", "#FFCC00",
-    "#84CC16", "#34C759", "#00C7BE", "#007AFF",
-    "#1E3F8A", "#AF52DE", "#C4B5FD", "#E040FB",
-    "#FF6B9D", "#C2185B", "#A0845C", "#8E8E93",
+    "#FF3B30", "#FF6F61", "#FF9500", "#FFCC00", "#84CC16", "#34C759", "#00C7BE", "#007AFF",
+    "#1E3F8A", "#AF52DE", "#C4B5FD", "#E040FB", "#FF6B9D", "#C2185B", "#A0845C", "#8E8E93",
 ];
 
 // ============================================================
@@ -156,12 +154,11 @@ async fn check_admin(
 
 /// 그룹 멤버 수 조회
 async fn get_member_count(pool: &PgPool, group_id: Uuid) -> Result<i64, AppError> {
-    let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM group_members WHERE group_id = $1")
-            .bind(group_id)
-            .fetch_one(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM group_members WHERE group_id = $1")
+        .bind(group_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(count.0)
 }
 
@@ -194,13 +191,11 @@ async fn build_group_response(
     let row = match row {
         Some(r) => r,
         None => {
-            let group_exists = sqlx::query_as::<_, (Uuid,)>(
-                "SELECT id FROM groups WHERE id = $1",
-            )
-            .bind(group_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+            let group_exists = sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
+                .bind(group_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
 
             return if group_exists.is_none() {
                 Err(AppError::NotFound("그룹을 찾을 수 없습니다".to_string()))
@@ -302,9 +297,8 @@ pub async fn create_group(
         }
     }
 
-    let group = group_row.ok_or_else(|| {
-        AppError::Internal("초대 코드 생성에 실패했습니다".to_string())
-    })?;
+    let group =
+        group_row.ok_or_else(|| AppError::Internal("초대 코드 생성에 실패했습니다".to_string()))?;
 
     // 생성자를 admin으로 등록 — 같은 트랜잭션
     sqlx::query(
@@ -336,14 +330,12 @@ pub async fn preview_group(
 ) -> Result<GroupPreviewResponse, AppError> {
     let normalized = invite_code.trim().to_uppercase();
 
-    let group = sqlx::query_as::<_, Group>(
-        "SELECT * FROM groups WHERE invite_code = $1",
-    )
-    .bind(&normalized)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("그룹을 찾을 수 없습니다".to_string()))?;
+    let group = sqlx::query_as::<_, Group>("SELECT * FROM groups WHERE invite_code = $1")
+        .bind(&normalized)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("그룹을 찾을 수 없습니다".to_string()))?;
 
     let member_count = get_member_count(pool, group.id).await?;
 
@@ -388,14 +380,12 @@ pub async fn join_group(
     let normalized = invite_code.trim().to_uppercase();
 
     // 그룹 조회 (트랜잭션 밖 -- 그룹 존재 확인은 읽기 전용)
-    let group = sqlx::query_as::<_, Group>(
-        "SELECT * FROM groups WHERE invite_code = $1",
-    )
-    .bind(&normalized)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("그룹을 찾을 수 없습니다".to_string()))?;
+    let group = sqlx::query_as::<_, Group>("SELECT * FROM groups WHERE invite_code = $1")
+        .bind(&normalized)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("그룹을 찾을 수 없습니다".to_string()))?;
 
     // 트랜잭션: 멤버십 확인 + 정원 확인 + INSERT를 원자적으로 실행
     let mut tx = pool
@@ -414,19 +404,22 @@ pub async fn join_group(
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
     if existing.is_some() {
-        return Err(AppError::Conflict("이미 그룹에 가입되어 있습니다".to_string()));
+        return Err(AppError::Conflict(
+            "이미 그룹에 가입되어 있습니다".to_string(),
+        ));
     }
 
     // 정원 확인 (트랜잭션 안에서)
-    let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM group_members WHERE group_id = $1")
-            .bind(group.id)
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM group_members WHERE group_id = $1")
+        .bind(group.id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
     if count.0 >= group.max_members as i64 {
-        return Err(AppError::BadRequest("그룹 정원이 가득 찼습니다".to_string()));
+        return Err(AppError::BadRequest(
+            "그룹 정원이 가득 찼습니다".to_string(),
+        ));
     }
 
     // 멤버 추가 (PK 충돌 시 Conflict로 처리)
@@ -447,7 +440,9 @@ pub async fn join_group(
                     .constraint()
                     .map_or(false, |c| c.contains("group_members_pkey")) =>
         {
-            return Err(AppError::Conflict("이미 그룹에 가입되어 있습니다".to_string()));
+            return Err(AppError::Conflict(
+                "이미 그룹에 가입되어 있습니다".to_string(),
+            ));
         }
         Err(e) => return Err(AppError::Internal(e.to_string())),
     }
@@ -462,11 +457,7 @@ pub async fn join_group(
 }
 
 /// 그룹 탈퇴 -- 호스트는 탈퇴 불가
-pub async fn leave_group(
-    pool: &PgPool,
-    user_uid: &str,
-    group_id: Uuid,
-) -> Result<(), AppError> {
+pub async fn leave_group(pool: &PgPool, user_uid: &str, group_id: Uuid) -> Result<(), AppError> {
     let member = check_member(pool, user_uid, group_id).await?;
 
     if member.role == ROLE_ADMIN {
@@ -600,11 +591,7 @@ pub async fn update_group(
 }
 
 /// 그룹 삭제 -- 호스트만 가능, cascade 처리
-pub async fn delete_group(
-    pool: &PgPool,
-    user_uid: &str,
-    group_id: Uuid,
-) -> Result<(), AppError> {
+pub async fn delete_group(pool: &PgPool, user_uid: &str, group_id: Uuid) -> Result<(), AppError> {
     check_admin(pool, user_uid, group_id).await?;
 
     sqlx::query("DELETE FROM groups WHERE id = $1")
@@ -787,22 +774,36 @@ pub async fn fetch_my_groups(
 
     let result = rows
         .into_iter()
-        .map(|(id, name, description, image_url, max_members, role, group_color, last_activity_at, last_read_at, joined_at, member_count)| {
-            let has_new_activity = last_activity_at > last_read_at;
-
-            GroupSummaryResponse {
-                group_id: id.to_string(),
+        .map(
+            |(
+                id,
                 name,
                 description,
                 image_url,
                 max_members,
-                member_count,
                 role,
                 group_color,
-                has_new_activity,
+                last_activity_at,
+                last_read_at,
                 joined_at,
-            }
-        })
+                member_count,
+            )| {
+                let has_new_activity = last_activity_at > last_read_at;
+
+                GroupSummaryResponse {
+                    group_id: id.to_string(),
+                    name,
+                    description,
+                    image_url,
+                    max_members,
+                    member_count,
+                    role,
+                    group_color,
+                    has_new_activity,
+                    joined_at,
+                }
+            },
+        )
         .collect();
 
     Ok(result)
@@ -840,16 +841,16 @@ pub async fn fetch_group_members(
 
     Ok(members
         .into_iter()
-        .map(|(user_id, nickname, profile_url, role, group_color, joined_at)| {
-            GroupMemberResponse {
+        .map(
+            |(user_id, nickname, profile_url, role, group_color, joined_at)| GroupMemberResponse {
                 user_id,
                 nickname,
                 profile_url,
                 role,
                 group_color,
                 joined_at,
-            }
-        })
+            },
+        )
         .collect())
 }
 
@@ -925,9 +926,7 @@ pub async fn update_group_color(
 
     // 팔레트 검증
     if !GROUP_COLOR_PALETTE.contains(&req.color.as_str()) {
-        return Err(AppError::BadRequest(
-            "허용되지 않은 색상입니다".to_string(),
-        ));
+        return Err(AppError::BadRequest("허용되지 않은 색상입니다".to_string()));
     }
 
     sqlx::query(

--- a/infra/rust-backend/src/services/mod.rs
+++ b/infra/rust-backend/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod group_service;
+pub mod schedule_service;
 pub mod user_service;

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1303,7 +1303,7 @@ pub async fn get_calendar_schedules(
         "SELECT id, user_id, title, emoji, description, \
          start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
          location_name, location_address, location_latitude, location_longitude, \
-         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         reminder_minutes_before, frequency, \
          days_of_week, day_of_month, \
          series_start_date, series_end_date, excluded_dates, overrides, \
          created_at, updated_at \
@@ -1488,7 +1488,7 @@ pub async fn check_conflicts(
         "SELECT id, user_id, title, emoji, description, \
          start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
          location_name, location_address, location_latitude, location_longitude, \
-         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         reminder_minutes_before, frequency, \
          days_of_week, day_of_month, \
          series_start_date, series_end_date, excluded_dates, overrides, \
          created_at, updated_at \
@@ -1933,7 +1933,7 @@ pub async fn get_recurring_schedules(
         "SELECT id, user_id, title, emoji, description, \
          start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
          location_name, location_address, location_latitude, location_longitude, \
-         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         reminder_minutes_before, frequency, \
          days_of_week, day_of_month, \
          series_start_date, series_end_date, excluded_dates, overrides, \
          created_at, updated_at \

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use serde::Deserialize;
@@ -10,6 +12,31 @@ use crate::models::schedule::*;
 // ============================================================
 // 헬퍼
 // ============================================================
+
+/// 여러 일정의 투표 정보를 한 번의 쿼리로 조회하여 schedule_id별로 그룹화
+async fn fetch_votes_batched(
+    pool: &PgPool,
+    schedule_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<ScheduleVote>>, AppError> {
+    if schedule_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let votes = sqlx::query_as::<_, ScheduleVote>(
+        "SELECT schedule_id, user_id, status, responded_at \
+         FROM schedule_votes WHERE schedule_id = ANY($1)",
+    )
+    .bind(schedule_ids)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut map: HashMap<Uuid, Vec<ScheduleVote>> = HashMap::new();
+    for vote in votes {
+        map.entry(vote.schedule_id).or_default().push(vote);
+    }
+    Ok(map)
+}
 
 /// 제목 유효성 검증: trim, 비어있지 않음, 최대 30자
 fn validate_title(title: &str) -> Result<String, AppError> {
@@ -1123,20 +1150,16 @@ pub async fn get_group_schedules(
         }
     };
 
-    // 각 일정의 투표 정보 조회
-    let mut data: Vec<ScheduleResponse> = Vec::with_capacity(schedules.len());
-    for schedule in &schedules {
-        let votes = sqlx::query_as::<_, ScheduleVote>(
-            "SELECT schedule_id, user_id, status, responded_at \
-             FROM schedule_votes WHERE schedule_id = $1",
-        )
-        .bind(schedule.id)
-        .fetch_all(pool)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-
-        data.push(build_schedule_response(schedule, votes));
-    }
+    // 각 일정의 투표 정보 배치 조회
+    let schedule_ids: Vec<Uuid> = schedules.iter().map(|s| s.id).collect();
+    let mut votes_map = fetch_votes_batched(pool, &schedule_ids).await?;
+    let data: Vec<ScheduleResponse> = schedules
+        .iter()
+        .map(|s| {
+            let votes = votes_map.remove(&s.id).unwrap_or_default();
+            build_schedule_response(s, votes)
+        })
+        .collect();
 
     // 커서: 반환된 항목이 limit개이면 마지막 항목의 start_at
     let cursor = if schedules.len() as i64 >= limit {
@@ -1187,19 +1210,15 @@ pub async fn get_home_schedules(
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    let mut result: Vec<ScheduleResponse> = Vec::with_capacity(schedules.len());
-    for schedule in &schedules {
-        let votes = sqlx::query_as::<_, ScheduleVote>(
-            "SELECT schedule_id, user_id, status, responded_at \
-             FROM schedule_votes WHERE schedule_id = $1",
-        )
-        .bind(schedule.id)
-        .fetch_all(pool)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-
-        result.push(build_schedule_response(schedule, votes));
-    }
+    let schedule_ids: Vec<Uuid> = schedules.iter().map(|s| s.id).collect();
+    let mut votes_map = fetch_votes_batched(pool, &schedule_ids).await?;
+    let result: Vec<ScheduleResponse> = schedules
+        .iter()
+        .map(|s| {
+            let votes = votes_map.remove(&s.id).unwrap_or_default();
+            build_schedule_response(s, votes)
+        })
+        .collect();
 
     Ok(result)
 }
@@ -1279,19 +1298,14 @@ pub async fn get_calendar_schedules(
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    // ScheduleResponse 빌드
+    // ScheduleResponse 빌드 (group_schedules는 배치 조회, personal_schedules는 votes 없음)
+    let group_ids_for_votes: Vec<Uuid> = group_schedules.iter().map(|s| s.id).collect();
+    let mut votes_map = fetch_votes_batched(pool, &group_ids_for_votes).await?;
+
     let mut schedules_response: Vec<ScheduleResponse> = Vec::new();
 
     for schedule in &group_schedules {
-        let votes = sqlx::query_as::<_, ScheduleVote>(
-            "SELECT schedule_id, user_id, status, responded_at \
-             FROM schedule_votes WHERE schedule_id = $1",
-        )
-        .bind(schedule.id)
-        .fetch_all(pool)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-
+        let votes = votes_map.remove(&schedule.id).unwrap_or_default();
         schedules_response.push(build_schedule_response(schedule, votes));
     }
 

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1,4 +1,5 @@
-use chrono::{Datelike, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -37,14 +38,178 @@ fn validate_description(description: &Option<String>) -> Result<(), AppError> {
     Ok(())
 }
 
+fn validate_start_at(start_at: DateTime<Utc>) -> Result<(), AppError> {
+    if start_at <= Utc::now() {
+        return Err(AppError::BadRequest(
+            "시작 시간은 현재보다 미래여야 합니다".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_end_at(start_at: DateTime<Utc>, end_at: Option<DateTime<Utc>>) -> Result<(), AppError> {
+    if let Some(end_at) = end_at {
+        if end_at <= start_at {
+            return Err(AppError::BadRequest(
+                "종료 시간은 시작 시간 이후여야 합니다".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_description_blocks(
+    description_blocks: &Option<serde_json::Value>,
+) -> Result<(), AppError> {
+    if let Some(blocks) = description_blocks {
+        if let Some(arr) = blocks.as_array() {
+            if arr.len() > 20 {
+                return Err(AppError::BadRequest(
+                    "설명 블록은 최대 20개까지 허용됩니다".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_image_urls(image_urls: &Option<Vec<String>>) -> Result<(), AppError> {
+    if let Some(urls) = image_urls {
+        if urls.len() > 3 {
+            return Err(AppError::BadRequest(
+                "이미지는 최대 3개까지 허용됩니다".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_group_member_count(pool: &PgPool, group_id: Uuid) -> Result<i64, AppError> {
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM group_members WHERE group_id = $1")
+        .bind(group_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(count.0)
+}
+
+fn validate_group_minimum_participants(
+    minimum_participants: i16,
+    member_count: i64,
+) -> Result<(), AppError> {
+    if minimum_participants < 1 {
+        return Err(AppError::BadRequest(
+            "최소 참여 인원은 1명 이상이어야 합니다".to_string(),
+        ));
+    }
+
+    if minimum_participants == 1 && member_count > 1 {
+        return Err(AppError::BadRequest(
+            "최소 참여 인원 1명은 1인 그룹에서만 허용됩니다".to_string(),
+        ));
+    }
+
+    if minimum_participants < 2 && member_count <= 0 {
+        return Err(AppError::BadRequest(
+            "그룹 멤버 수가 유효하지 않습니다".to_string(),
+        ));
+    }
+
+    if minimum_participants < 2 && member_count == 1 {
+        return Ok(());
+    }
+
+    if minimum_participants < 2 {
+        return Err(AppError::BadRequest(
+            "최소 참여 인원은 2명 이상이어야 합니다".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn effective_end_at(start_at: DateTime<Utc>, end_at: Option<DateTime<Utc>>) -> DateTime<Utc> {
+    end_at.unwrap_or(start_at)
+}
+
+fn parse_timezone(timezone: Option<&str>) -> Result<Tz, AppError> {
+    timezone
+        .unwrap_or("UTC")
+        .parse::<Tz>()
+        .map_err(|_| AppError::BadRequest("유효하지 않은 timezone입니다".to_string()))
+}
+
+fn resolve_local_datetime(
+    timezone: Tz,
+    date: NaiveDate,
+    time: &TimeComponents,
+) -> Result<DateTime<Utc>, AppError> {
+    let local = NaiveDateTime::new(
+        date,
+        chrono::NaiveTime::from_hms_opt(time.hour as u32, time.minute as u32, 0).ok_or_else(
+            || AppError::Internal("반복 일정 시간 값이 유효하지 않습니다".to_string()),
+        )?,
+    );
+
+    let zoned = match timezone.from_local_datetime(&local) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(dt, _) => dt,
+        LocalResult::None => {
+            return Err(AppError::BadRequest(
+                "timezone 기준으로 반복 일정을 해석할 수 없습니다".to_string(),
+            ));
+        }
+    };
+
+    Ok(zoned.with_timezone(&Utc))
+}
+
+fn json_get<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a serde_json::Value> {
+    keys.iter().find_map(|key| value.get(*key))
+}
+
+fn parse_override_time(
+    override_entry: Option<&serde_json::Value>,
+    keys: &[&str],
+) -> Option<TimeComponents> {
+    let value = override_entry.and_then(|entry| json_get(entry, keys))?;
+    let hour = value.get("hour")?.as_i64()? as i16;
+    let minute = value.get("minute")?.as_i64()? as i16;
+
+    Some(TimeComponents { hour, minute })
+}
+
+fn parse_override_location(override_entry: Option<&serde_json::Value>) -> Option<LocationResponse> {
+    let value = override_entry.and_then(|entry| entry.get("location"))?;
+    let name = value.get("name")?.as_str()?.to_string();
+
+    Some(LocationResponse {
+        name,
+        address: value
+            .get("address")
+            .and_then(|v| v.as_str())
+            .map(|v| v.to_string()),
+        latitude: value.get("latitude").and_then(|v| v.as_f64()),
+        longitude: value.get("longitude").and_then(|v| v.as_f64()),
+    })
+}
+
 /// Schedule DB 행 + votes로 ScheduleResponse 빌드
 fn build_schedule_response(schedule: &Schedule, votes: Vec<ScheduleVote>) -> ScheduleResponse {
-    let location = schedule.location_name.as_ref().map(|name| LocationResponse {
-        name: name.clone(),
-        address: schedule.location_address.clone(),
-        latitude: schedule.location_latitude,
-        longitude: schedule.location_longitude,
-    });
+    let location = schedule
+        .location_name
+        .as_ref()
+        .map(|name| LocationResponse {
+            name: name.clone(),
+            address: schedule.location_address.clone(),
+            latitude: schedule.location_latitude,
+            longitude: schedule.location_longitude,
+        });
 
     let is_group = schedule.schedule_type == ScheduleType::Group;
 
@@ -131,15 +296,12 @@ pub async fn create_schedule(
     // 공통 검증
     let title = validate_title(&req.title)?;
     validate_description(&req.description)?;
+    validate_start_at(req.start_at)?;
+    validate_end_at(req.start_at, req.end_at)?;
+    validate_description_blocks(&req.description_blocks)?;
 
-    // end_at > start_at 검증 (strictly greater, equal is invalid)
-    if let Some(end_at) = req.end_at {
-        if end_at <= req.start_at {
-            return Err(AppError::BadRequest(
-                "종료 시간은 시작 시간 이후여야 합니다".to_string(),
-            ));
-        }
-    }
+    // P20: 기본 이모지
+    let emoji = req.emoji.unwrap_or_else(|| "\u{1F4C5}".to_string());
 
     match req.schedule_type {
         ScheduleType::Group => {
@@ -149,49 +311,25 @@ pub async fn create_schedule(
             })?;
 
             let minimum_participants = req.minimum_participants.ok_or_else(|| {
-                AppError::BadRequest(
-                    "그룹 일정에는 minimum_participants가 필요합니다".to_string(),
-                )
+                AppError::BadRequest("그룹 일정에는 minimum_participants가 필요합니다".to_string())
             })?;
 
-            if minimum_participants < 1 {
+            if req.reminder_minutes_before.is_some() {
                 return Err(AppError::BadRequest(
-                    "최소 참여 인원은 1명 이상이어야 합니다".to_string(),
+                    "그룹 일정에는 reminder_minutes_before를 설정할 수 없습니다".to_string(),
                 ));
             }
-
-            // description_blocks 최대 20
-            if let Some(ref blocks) = req.description_blocks {
-                if let Some(arr) = blocks.as_array() {
-                    if arr.len() > 20 {
-                        return Err(AppError::BadRequest(
-                            "설명 블록은 최대 20개까지 허용됩니다".to_string(),
-                        ));
-                    }
-                }
-            }
-
-            // image_urls 최대 3
-            if let Some(ref urls) = req.image_urls {
-                if urls.len() > 3 {
-                    return Err(AppError::BadRequest(
-                        "이미지는 최대 3개까지 허용됩니다".to_string(),
-                    ));
-                }
-            }
+            validate_image_urls(&req.image_urls)?;
 
             // 그룹 존재 확인
-            let group_exists =
-                sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
-                    .bind(group_id)
-                    .fetch_optional(pool)
-                    .await
-                    .map_err(|e| AppError::Internal(e.to_string()))?;
+            let group_exists = sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
+                .bind(group_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
 
             if group_exists.is_none() {
-                return Err(AppError::NotFound(
-                    "그룹을 찾을 수 없습니다".to_string(),
-                ));
+                return Err(AppError::NotFound("그룹을 찾을 수 없습니다".to_string()));
             }
 
             // 멤버십 확인
@@ -207,6 +345,9 @@ pub async fn create_schedule(
             if membership.is_none() {
                 return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
             }
+
+            let member_count = get_group_member_count(pool, group_id).await?;
+            validate_group_minimum_participants(minimum_participants, member_count)?;
 
             // is_confirmed: minimum_participants <= 1 이면 호스트 자동수락으로 즉시 확정
             let is_confirmed = minimum_participants <= 1;
@@ -234,7 +375,7 @@ pub async fn create_schedule(
             )
             .bind(user_id)
             .bind(&title)
-            .bind(&req.emoji)
+            .bind(Some(&emoji))
             .bind(&req.description)
             .bind(&req.description_blocks)
             .bind(req.start_at)
@@ -284,6 +425,15 @@ pub async fn create_schedule(
                 ));
             }
 
+            if req.minimum_participants.is_some()
+                || req.tracking_start_minutes_before.is_some()
+                || req.image_urls.is_some()
+            {
+                return Err(AppError::BadRequest(
+                    "개인 일정에는 그룹 일정 전용 필드를 설정할 수 없습니다".to_string(),
+                ));
+            }
+
             let location_name = req.location.as_ref().map(|l| l.name.clone());
             let location_address = req.location.as_ref().and_then(|l| l.address.clone());
             let location_latitude = req.location.as_ref().and_then(|l| l.latitude);
@@ -299,7 +449,7 @@ pub async fn create_schedule(
             )
             .bind(user_id)
             .bind(&title)
-            .bind(&req.emoji)
+            .bind(Some(&emoji))
             .bind(&req.description)
             .bind(&req.description_blocks)
             .bind(req.start_at)
@@ -340,9 +490,9 @@ pub async fn get_schedule(
     // 권한 확인
     match schedule.schedule_type {
         ScheduleType::Group => {
-            let group_id = schedule.group_id.ok_or_else(|| {
-                AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
-            })?;
+            let group_id = schedule
+                .group_id
+                .ok_or_else(|| AppError::Internal("그룹 일정에 group_id가 없습니다".to_string()))?;
 
             let membership = sqlx::query_as::<_, (String,)>(
                 "SELECT user_id FROM group_members WHERE group_id = $1 AND user_id = $2",
@@ -440,6 +590,57 @@ pub async fn update_schedule(
     // 제목 검증
     if let Some(ref title) = req.title {
         validate_title(title)?;
+    }
+
+    if let Some(description) = &req.description {
+        validate_description(description)?;
+    }
+
+    if let Some(description_blocks) = &req.description_blocks {
+        validate_description_blocks(description_blocks)?;
+    }
+
+    if let Some(image_urls) = &req.image_urls {
+        validate_image_urls(image_urls)?;
+    }
+
+    let next_start_at = req.start_at.unwrap_or(schedule.start_at);
+    let next_end_at = match req.end_at {
+        Some(end_at) => end_at,
+        None => schedule.end_at,
+    };
+
+    validate_start_at(next_start_at)?;
+    validate_end_at(next_start_at, next_end_at)?;
+
+    match schedule.schedule_type {
+        ScheduleType::Group => {
+            if req.reminder_minutes_before.is_some() {
+                return Err(AppError::BadRequest(
+                    "그룹 일정에는 reminder_minutes_before를 설정할 수 없습니다".to_string(),
+                ));
+            }
+        }
+        ScheduleType::Personal => {
+            if req.minimum_participants.is_some()
+                || req.tracking_start_minutes_before.is_some()
+                || req.image_urls.is_some()
+            {
+                return Err(AppError::BadRequest(
+                    "개인 일정에는 그룹 일정 전용 필드를 설정할 수 없습니다".to_string(),
+                ));
+            }
+        }
+    }
+
+    if let Some(minimum_participants) = req.minimum_participants {
+        let group_id = schedule.group_id.ok_or_else(|| {
+            AppError::BadRequest(
+                "개인 일정에는 minimum_participants를 설정할 수 없습니다".to_string(),
+            )
+        })?;
+        let member_count = get_group_member_count(pool, group_id).await?;
+        validate_group_minimum_participants(minimum_participants, member_count)?;
     }
 
     // 동적 UPDATE 쿼리 빌드
@@ -591,8 +792,36 @@ pub async fn update_schedule(
     // WHERE id = $N
     query = query.bind(schedule_id);
 
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
     query
-        .execute(pool)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if let Some(minimum_participants) = req.minimum_participants {
+        let accepted_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM schedule_votes \
+             WHERE schedule_id = $1 AND status = 'accepted'::vote_status",
+        )
+        .bind(schedule_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        let is_confirmed = accepted_count.0 >= minimum_participants as i64;
+        sqlx::query("UPDATE schedules SET is_confirmed = $1 WHERE id = $2")
+            .bind(is_confirmed)
+            .bind(schedule_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+
+    tx.commit()
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
@@ -694,9 +923,9 @@ pub async fn respond_schedule(
         ));
     }
 
-    let group_id = schedule.group_id.ok_or_else(|| {
-        AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
-    })?;
+    let group_id = schedule
+        .group_id
+        .ok_or_else(|| AppError::Internal("그룹 일정에 group_id가 없습니다".to_string()))?;
 
     // 멤버십 확인
     let membership = sqlx::query_as::<_, (String,)>(
@@ -712,6 +941,9 @@ pub async fn respond_schedule(
         return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
     }
 
+    // 전환 감지: 이전 확정 상태 캡처
+    let was_confirmed = schedule.is_confirmed.unwrap_or(false);
+
     // 트랜잭션
     let mut tx = pool
         .begin()
@@ -720,14 +952,12 @@ pub async fn respond_schedule(
 
     if status == "pending" {
         // P28: pending이면 투표 삭제
-        sqlx::query(
-            "DELETE FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2",
-        )
-        .bind(schedule_id)
-        .bind(user_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+        sqlx::query("DELETE FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2")
+            .bind(schedule_id)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
     } else {
         // P27: 이미 같은 상태면 no-op
         let current_vote = sqlx::query_as::<_, (String,)>(
@@ -739,9 +969,7 @@ pub async fn respond_schedule(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
-        let already_same = current_vote
-            .as_ref()
-            .is_some_and(|(s,)| s == &status);
+        let already_same = current_vote.as_ref().is_some_and(|(s,)| s == &status);
 
         if !already_same {
             // UPSERT: INSERT ON CONFLICT UPDATE
@@ -784,8 +1012,8 @@ pub async fn respond_schedule(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    // confirmed_schedule 빌드 (is_confirmed && status == "accepted")
-    let confirmed_schedule = if new_is_confirmed && status == "accepted" {
+    // confirmed_schedule 빌드 (미확정 → 확정 전환 시에만)
+    let confirmed_schedule = if !was_confirmed && new_is_confirmed && status == "accepted" {
         Some(CalendarSyncSchedule {
             id: schedule.id,
             title: schedule.title.clone(),
@@ -818,17 +1046,14 @@ pub async fn get_group_schedules(
     query: GroupScheduleQuery,
 ) -> Result<PaginatedScheduleResponse, AppError> {
     // 그룹 존재 확인
-    let group_exists =
-        sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
-            .bind(group_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+    let group_exists = sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
+        .bind(group_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
     if group_exists.is_none() {
-        return Err(AppError::NotFound(
-            "그룹을 찾을 수 없습니다".to_string(),
-        ));
+        return Err(AppError::NotFound("그룹을 찾을 수 없습니다".to_string()));
     }
 
     // 멤버십 확인
@@ -850,41 +1075,35 @@ pub async fn get_group_schedules(
     let now = Utc::now();
 
     let schedules = match status {
-        "past" => {
-            match query.cursor {
-                Some(cursor) => {
-                    sqlx::query_as::<_, Schedule>(
-                        "SELECT * FROM schedules \
+        "past" => match query.cursor {
+            Some(cursor) => sqlx::query_as::<_, Schedule>(
+                "SELECT * FROM schedules \
                          WHERE group_id = $1 AND schedule_type = 'group' \
                            AND start_at < $2 AND start_at < $3 \
                          ORDER BY start_at DESC \
                          LIMIT $4",
-                    )
-                    .bind(group_id)
-                    .bind(now)
-                    .bind(cursor)
-                    .bind(limit)
-                    .fetch_all(pool)
-                    .await
-                    .map_err(|e| AppError::Internal(e.to_string()))?
-                }
-                None => {
-                    sqlx::query_as::<_, Schedule>(
-                        "SELECT * FROM schedules \
+            )
+            .bind(group_id)
+            .bind(now)
+            .bind(cursor)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+            None => sqlx::query_as::<_, Schedule>(
+                "SELECT * FROM schedules \
                          WHERE group_id = $1 AND schedule_type = 'group' \
                            AND start_at < $2 \
                          ORDER BY start_at DESC \
                          LIMIT $3",
-                    )
-                    .bind(group_id)
-                    .bind(now)
-                    .bind(limit)
-                    .fetch_all(pool)
-                    .await
-                    .map_err(|e| AppError::Internal(e.to_string()))?
-                }
-            }
-        }
+            )
+            .bind(group_id)
+            .bind(now)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+        },
         _ => {
             // "active": start_at >= NOW(), ASC
             sqlx::query_as::<_, Schedule>(
@@ -937,16 +1156,15 @@ pub async fn get_home_schedules(
     let now = Utc::now();
 
     // 유저가 속한 그룹 ID 목록
-    let group_ids: Vec<Uuid> = sqlx::query_as::<_, (Uuid,)>(
-        "SELECT group_id FROM group_members WHERE user_id = $1",
-    )
-    .bind(user_id)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .into_iter()
-    .map(|(id,)| id)
-    .collect();
+    let group_ids: Vec<Uuid> =
+        sqlx::query_as::<_, (Uuid,)>("SELECT group_id FROM group_members WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .into_iter()
+            .map(|(id,)| id)
+            .collect();
 
     if group_ids.is_empty() {
         return Ok(Vec::new());
@@ -991,18 +1209,18 @@ pub async fn get_calendar_schedules(
     query: CalendarQuery,
 ) -> Result<CalendarResponse, AppError> {
     let accepted_only = query.accepted_only.unwrap_or(false);
+    let timezone = parse_timezone(query.timezone.as_deref())?;
 
     // 유저가 속한 그룹 ID 목록
-    let group_ids: Vec<Uuid> = sqlx::query_as::<_, (Uuid,)>(
-        "SELECT group_id FROM group_members WHERE user_id = $1",
-    )
-    .bind(user_id)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .into_iter()
-    .map(|(id,)| id)
-    .collect();
+    let group_ids: Vec<Uuid> =
+        sqlx::query_as::<_, (Uuid,)>("SELECT group_id FROM group_members WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .into_iter()
+            .map(|(id,)| id)
+            .collect();
 
     // 그룹일정 조회 (date range)
     let group_schedules = if group_ids.is_empty() {
@@ -1015,7 +1233,7 @@ pub async fn get_calendar_schedules(
              WHERE s.schedule_type = 'group' \
                AND s.group_id = ANY($1) \
                AND s.start_at < $2 \
-               AND (s.end_at > $3 OR s.end_at IS NULL) \
+               AND COALESCE(s.end_at, s.start_at) >= $3 \
                AND sv.user_id = $4 \
                AND sv.status = 'accepted' \
              ORDER BY s.start_at ASC",
@@ -1033,7 +1251,7 @@ pub async fn get_calendar_schedules(
              WHERE schedule_type = 'group' \
                AND group_id = ANY($1) \
                AND start_at < $2 \
-               AND (end_at > $3 OR end_at IS NULL) \
+               AND COALESCE(end_at, start_at) >= $3 \
              ORDER BY start_at ASC",
         )
         .bind(&group_ids)
@@ -1050,7 +1268,7 @@ pub async fn get_calendar_schedules(
          WHERE schedule_type = 'personal' \
            AND user_id = $1 \
            AND start_at < $2 \
-           AND (end_at > $3 OR end_at IS NULL) \
+           AND COALESCE(end_at, start_at) >= $3 \
          ORDER BY start_at ASC",
     )
     .bind(user_id)
@@ -1096,14 +1314,21 @@ pub async fn get_calendar_schedules(
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    let range_start = query.start.date_naive();
-    let range_end = query.end.date_naive();
+    let range_start = query.start.with_timezone(&timezone).date_naive();
+    let range_end = query.end.with_timezone(&timezone).date_naive();
 
     let mut recurring_instances: Vec<RecurringInstance> = Vec::new();
     for rs in &recurring_schedules {
-        let mut instances = expand_recurring_in_range(rs, range_start, range_end);
+        let mut instances = expand_recurring_in_range(rs, range_start, range_end, timezone);
         recurring_instances.append(&mut instances);
     }
+
+    recurring_instances.sort_by(|a, b| {
+        a.date
+            .cmp(&b.date)
+            .then(a.start_time.hour.cmp(&b.start_time.hour))
+            .then(a.start_time.minute.cmp(&b.start_time.minute))
+    });
 
     Ok(CalendarResponse {
         schedules: schedules_response,
@@ -1160,83 +1385,47 @@ pub async fn check_conflicts(
     req: CheckConflictsRequest,
 ) -> Result<Vec<ScheduleConflict>, AppError> {
     let min_gap = Duration::minutes(req.min_gap_minutes.unwrap_or(0) as i64);
+    let timezone = parse_timezone(req.timezone.as_deref())?;
     let exclude_ids = req.exclude_ids.unwrap_or_default();
+    let proposed_end = effective_end_at(req.start_at, req.end_at);
 
     // 검색 범위를 min_gap만큼 확장
     let search_start = req.start_at - min_gap;
-    let search_end = req.end_at.map(|e| e + min_gap);
+    let search_end = proposed_end + min_gap;
 
     // 유저의 accepted 그룹일정 조회
-    let group_schedules = match search_end {
-        Some(end) => {
-            sqlx::query_as::<_, Schedule>(
-                "SELECT s.* FROM schedules s \
-                 JOIN schedule_votes sv ON s.id = sv.schedule_id \
-                 WHERE sv.user_id = $1 \
-                   AND sv.status = 'accepted' \
-                   AND s.schedule_type = 'group' \
-                   AND s.start_at < $2 \
-                   AND (s.end_at > $3 OR s.end_at IS NULL) \
-                 ORDER BY s.start_at ASC",
-            )
-            .bind(user_id)
-            .bind(end)
-            .bind(search_start)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?
-        }
-        None => {
-            sqlx::query_as::<_, Schedule>(
-                "SELECT s.* FROM schedules s \
-                 JOIN schedule_votes sv ON s.id = sv.schedule_id \
-                 WHERE sv.user_id = $1 \
-                   AND sv.status = 'accepted' \
-                   AND s.schedule_type = 'group' \
-                   AND (s.end_at > $2 OR s.end_at IS NULL) \
-                 ORDER BY s.start_at ASC",
-            )
-            .bind(user_id)
-            .bind(search_start)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?
-        }
-    };
+    let group_schedules = sqlx::query_as::<_, Schedule>(
+        "SELECT s.* FROM schedules s \
+         JOIN schedule_votes sv ON s.id = sv.schedule_id \
+         WHERE sv.user_id = $1 \
+           AND sv.status = 'accepted' \
+           AND s.schedule_type = 'group' \
+           AND s.start_at <= $2 \
+           AND COALESCE(s.end_at, s.start_at) >= $3 \
+         ORDER BY s.start_at ASC",
+    )
+    .bind(user_id)
+    .bind(search_end)
+    .bind(search_start)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
 
     // 유저의 개인일정 조회
-    let personal_schedules = match search_end {
-        Some(end) => {
-            sqlx::query_as::<_, Schedule>(
-                "SELECT * FROM schedules \
-                 WHERE user_id = $1 \
-                   AND schedule_type = 'personal' \
-                   AND start_at < $2 \
-                   AND (end_at > $3 OR end_at IS NULL) \
-                 ORDER BY start_at ASC",
-            )
-            .bind(user_id)
-            .bind(end)
-            .bind(search_start)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?
-        }
-        None => {
-            sqlx::query_as::<_, Schedule>(
-                "SELECT * FROM schedules \
-                 WHERE user_id = $1 \
-                   AND schedule_type = 'personal' \
-                   AND (end_at > $2 OR end_at IS NULL) \
-                 ORDER BY start_at ASC",
-            )
-            .bind(user_id)
-            .bind(search_start)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?
-        }
-    };
+    let personal_schedules = sqlx::query_as::<_, Schedule>(
+        "SELECT * FROM schedules \
+         WHERE user_id = $1 \
+           AND schedule_type = 'personal' \
+           AND start_at <= $2 \
+           AND COALESCE(end_at, start_at) >= $3 \
+         ORDER BY start_at ASC",
+    )
+    .bind(user_id)
+    .bind(search_end)
+    .bind(search_start)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let all_schedules: Vec<&Schedule> = group_schedules
         .iter()
@@ -1244,34 +1433,39 @@ pub async fn check_conflicts(
         .filter(|s| !exclude_ids.contains(&s.id))
         .collect();
 
-    let proposed_start = req.start_at;
-    let proposed_end = req.end_at;
-
     let mut conflicts: Vec<ScheduleConflict> = Vec::new();
 
     for existing in &all_schedules {
-        let ex_start = existing.start_at;
-        let ex_end = existing.end_at;
-
+        let is_overlapping = ranges_overlap(
+            req.start_at,
+            Some(proposed_end),
+            existing.start_at,
+            Some(effective_end_at(existing.start_at, existing.end_at)),
+        );
         // overlap 계산
         let overlap_minutes = calculate_overlap_minutes(
-            proposed_start,
-            proposed_end,
-            ex_start,
-            ex_end,
+            req.start_at,
+            Some(proposed_end),
+            existing.start_at,
+            Some(effective_end_at(existing.start_at, existing.end_at)),
         );
 
         // gap 계산 (겹치지 않는 경우)
-        let gap_minutes = if overlap_minutes > 0 {
+        let gap_minutes = if is_overlapping {
             0
         } else {
-            calculate_gap_minutes(proposed_start, proposed_end, ex_start, ex_end)
+            calculate_gap_minutes(
+                req.start_at,
+                Some(proposed_end),
+                existing.start_at,
+                Some(effective_end_at(existing.start_at, existing.end_at)),
+            )
         };
 
         let min_gap_minutes_val = req.min_gap_minutes.unwrap_or(0) as i64;
 
         // 겹치거나, gap이 min_gap 미만이면 충돌
-        if overlap_minutes > 0 || gap_minutes < min_gap_minutes_val {
+        if is_overlapping || gap_minutes < min_gap_minutes_val {
             let conflict_type = match existing.schedule_type {
                 ScheduleType::Group => "group",
                 ScheduleType::Personal => "personal",
@@ -1290,6 +1484,83 @@ pub async fn check_conflicts(
         }
     }
 
+    let recurring_schedules = sqlx::query_as::<_, RecurringSchedule>(
+        "SELECT id, user_id, title, emoji, description, \
+         start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
+         location_name, location_address, location_latitude, location_longitude, \
+         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         days_of_week, day_of_month, \
+         series_start_date, series_end_date, excluded_dates, overrides, \
+         created_at, updated_at \
+         FROM recurring_schedules WHERE user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let recurring_range_start = search_start.with_timezone(&timezone).date_naive();
+    let recurring_range_end = search_end.with_timezone(&timezone).date_naive();
+
+    for recurring_schedule in &recurring_schedules {
+        for instance in expand_recurring_in_range(
+            recurring_schedule,
+            recurring_range_start,
+            recurring_range_end,
+            timezone,
+        ) {
+            let instance_start =
+                resolve_local_datetime(timezone, instance.date, &instance.start_time)?;
+            let instance_end = match instance.end_time.as_ref() {
+                Some(end_time) => {
+                    let end_at = resolve_local_datetime(timezone, instance.date, end_time)?;
+                    Some(if end_at <= instance_start {
+                        end_at + Duration::days(1)
+                    } else {
+                        end_at
+                    })
+                }
+                None => None,
+            };
+            let is_overlapping = ranges_overlap(
+                req.start_at,
+                Some(proposed_end),
+                instance_start,
+                Some(effective_end_at(instance_start, instance_end)),
+            );
+            let overlap_minutes = calculate_overlap_minutes(
+                req.start_at,
+                Some(proposed_end),
+                instance_start,
+                Some(effective_end_at(instance_start, instance_end)),
+            );
+            let gap_minutes = if is_overlapping {
+                0
+            } else {
+                calculate_gap_minutes(
+                    req.start_at,
+                    Some(proposed_end),
+                    instance_start,
+                    Some(effective_end_at(instance_start, instance_end)),
+                )
+            };
+            let min_gap_minutes_val = req.min_gap_minutes.unwrap_or(0) as i64;
+
+            if is_overlapping || gap_minutes < min_gap_minutes_val {
+                conflicts.push(ScheduleConflict {
+                    id: format!("{}:{}", instance.recurring_schedule_id, instance.date),
+                    conflict_type: "recurring".to_string(),
+                    title: instance.title,
+                    emoji: instance.emoji,
+                    start_at: instance_start,
+                    end_at: instance_end,
+                    overlap_minutes,
+                    gap_minutes,
+                });
+            }
+        }
+    }
+
     // overlap 내림차순, gap 오름차순 정렬
     conflicts.sort_by(|a, b| {
         b.overlap_minutes
@@ -1304,6 +1575,26 @@ pub async fn check_conflicts(
 // 충돌 계산 헬퍼
 // ============================================================
 
+fn ranges_overlap(
+    start_a: chrono::DateTime<Utc>,
+    end_a: Option<chrono::DateTime<Utc>>,
+    start_b: chrono::DateTime<Utc>,
+    end_b: Option<chrono::DateTime<Utc>>,
+) -> bool {
+    let end_a = effective_end_at(start_a, end_a);
+    let end_b = effective_end_at(start_b, end_b);
+
+    if start_a == end_a && start_b == end_b {
+        start_a == start_b
+    } else if start_a == end_a {
+        start_a >= start_b && start_a < end_b
+    } else if start_b == end_b {
+        start_b >= start_a && start_b < end_a
+    } else {
+        start_a < end_b && end_a > start_b
+    }
+}
+
 /// 두 시간 범위의 겹침 시간(분)을 계산
 fn calculate_overlap_minutes(
     start_a: chrono::DateTime<Utc>,
@@ -1311,9 +1602,8 @@ fn calculate_overlap_minutes(
     start_b: chrono::DateTime<Utc>,
     end_b: Option<chrono::DateTime<Utc>>,
 ) -> i64 {
-    // end가 None인 경우 start + 1시간으로 간주
-    let end_a = end_a.unwrap_or(start_a + Duration::hours(1));
-    let end_b = end_b.unwrap_or(start_b + Duration::hours(1));
+    let end_a = effective_end_at(start_a, end_a);
+    let end_b = effective_end_at(start_b, end_b);
 
     let overlap_start = start_a.max(start_b);
     let overlap_end = end_a.min(end_b);
@@ -1332,8 +1622,8 @@ fn calculate_gap_minutes(
     start_b: chrono::DateTime<Utc>,
     end_b: Option<chrono::DateTime<Utc>>,
 ) -> i64 {
-    let end_a = end_a.unwrap_or(start_a + Duration::hours(1));
-    let end_b = end_b.unwrap_or(start_b + Duration::hours(1));
+    let end_a = effective_end_at(start_a, end_a);
+    let end_b = effective_end_at(start_b, end_b);
 
     if end_a <= start_b {
         (start_b - end_a).num_minutes()
@@ -1353,6 +1643,7 @@ fn expand_recurring_in_range(
     schedule: &RecurringSchedule,
     range_start: NaiveDate,
     range_end: NaiveDate,
+    _timezone: Tz,
 ) -> Vec<RecurringInstance> {
     let mut instances = Vec::new();
 
@@ -1368,12 +1659,9 @@ fn expand_recurring_in_range(
         return instances;
     }
 
-    let excluded_dates: Vec<NaiveDate> = schedule
-        .excluded_dates
-        .clone()
-        .unwrap_or_default();
+    let excluded_dates: Vec<NaiveDate> = schedule.excluded_dates.clone().unwrap_or_default();
 
-    // 오버라이드 파싱: { "YYYY-MM-DD": { "start_time": {...}, "end_time": {...}, "cancelled": bool } }
+    // 오버라이드 파싱: current app payload uses camelCase, legacy/service payload may use snake_case.
     let overrides_map: serde_json::Map<String, serde_json::Value> = schedule
         .overrides
         .as_ref()
@@ -1386,8 +1674,7 @@ fn expand_recurring_in_range(
             RecurrenceFrequency::Daily => true,
             RecurrenceFrequency::Weekly => {
                 if let Some(ref days) = schedule.days_of_week {
-                    // chrono: Monday=1, Sunday=7 (iso_weekday)
-                    let weekday = current.weekday().number_from_monday() as i16;
+                    let weekday = current.weekday().number_from_sunday() as i16;
                     days.contains(&weekday)
                 } else {
                     false
@@ -1408,31 +1695,19 @@ fn expand_recurring_in_range(
 
             // 오버라이드에서 cancelled 확인
             let is_cancelled = override_entry
-                .and_then(|v| v.get("cancelled"))
+                .and_then(|v| json_get(v, &["isCancelled", "cancelled"]))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
 
             if !is_cancelled {
                 // 오버라이드된 시간 또는 기본 시간
-                let start_time = override_entry
-                    .and_then(|v| v.get("start_time"))
-                    .and_then(|v| {
-                        let hour = v.get("hour")?.as_i64()? as i16;
-                        let minute = v.get("minute")?.as_i64()? as i16;
-                        Some(TimeComponents { hour, minute })
-                    })
+                let start_time = parse_override_time(override_entry, &["startTime", "start_time"])
                     .unwrap_or(TimeComponents {
                         hour: schedule.start_time_hour,
                         minute: schedule.start_time_minute,
                     });
 
-                let end_time = override_entry
-                    .and_then(|v| v.get("end_time"))
-                    .and_then(|v| {
-                        let hour = v.get("hour")?.as_i64()? as i16;
-                        let minute = v.get("minute")?.as_i64()? as i16;
-                        Some(TimeComponents { hour, minute })
-                    })
+                let end_time = parse_override_time(override_entry, &["endTime", "end_time"])
                     .or_else(|| {
                         schedule.end_time_hour.map(|h| TimeComponents {
                             hour: h,
@@ -1440,16 +1715,27 @@ fn expand_recurring_in_range(
                         })
                     });
 
-                let location = schedule.location_name.as_ref().map(|name| LocationResponse {
-                    name: name.clone(),
-                    address: schedule.location_address.clone(),
-                    latitude: schedule.location_latitude,
-                    longitude: schedule.location_longitude,
+                let location = parse_override_location(override_entry).or_else(|| {
+                    schedule
+                        .location_name
+                        .as_ref()
+                        .map(|name| LocationResponse {
+                            name: name.clone(),
+                            address: schedule.location_address.clone(),
+                            latitude: schedule.location_latitude,
+                            longitude: schedule.location_longitude,
+                        })
                 });
+
+                let title = override_entry
+                    .and_then(|v| v.get("title"))
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| schedule.title.clone());
 
                 instances.push(RecurringInstance {
                     recurring_schedule_id: schedule.id,
-                    title: schedule.title.clone(),
+                    title,
                     emoji: schedule.emoji.clone(),
                     date: current,
                     start_time,
@@ -1669,14 +1955,13 @@ pub async fn update_recurring_schedule(
     req: UpdateRecurringScheduleRequest,
 ) -> Result<(), AppError> {
     // 존재 확인
-    let existing = sqlx::query_as::<_, (String,)>(
-        "SELECT user_id FROM recurring_schedules WHERE id = $1",
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
+    let existing =
+        sqlx::query_as::<_, (String,)>("SELECT user_id FROM recurring_schedules WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
 
     // 소유권 확인
     if existing.0 != user_id {
@@ -1965,14 +2250,13 @@ pub async fn delete_recurring_schedule(
     id: Uuid,
 ) -> Result<(), AppError> {
     // 존재 확인
-    let existing = sqlx::query_as::<_, (String,)>(
-        "SELECT user_id FROM recurring_schedules WHERE id = $1",
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| AppError::Internal(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
+    let existing =
+        sqlx::query_as::<_, (String,)>("SELECT user_id FROM recurring_schedules WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
 
     // 소유권 확인
     if existing.0 != user_id {
@@ -1997,7 +2281,25 @@ pub async fn delete_recurring_schedule(
 pub async fn extract_schedule(
     _pool: &PgPool,
     _user_id: &str,
-    _req: ExtractScheduleRequest,
+    req: ExtractScheduleRequest,
 ) -> Result<ExtractScheduleResponse, AppError> {
-    todo!()
+    if req.text.is_none() && req.image_base64.is_none() {
+        return Err(AppError::BadRequest(
+            "text 또는 image_base64 중 하나는 필요합니다".to_string(),
+        ));
+    }
+
+    if let Some(text) = &req.text {
+        if text.chars().count() > 2000 {
+            return Err(AppError::BadRequest(
+                "text는 2000자 이하여야 합니다".to_string(),
+            ));
+        }
+    }
+
+    parse_timezone(req.timezone.as_deref())?;
+
+    Err(AppError::BadRequest(
+        "일정 추출 기능은 아직 지원되지 않습니다".to_string(),
+    ))
 }

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1,0 +1,131 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::errors::AppError;
+use crate::models::schedule::*;
+
+// ============================================================
+// 그룹/개인 일정 CRUD
+// ============================================================
+
+pub async fn create_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _req: CreateScheduleRequest,
+) -> Result<CreateScheduleResponse, AppError> {
+    todo!()
+}
+
+pub async fn get_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _schedule_id: Uuid,
+) -> Result<ScheduleResponse, AppError> {
+    todo!()
+}
+
+pub async fn update_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _schedule_id: Uuid,
+    _req: UpdateScheduleRequest,
+) -> Result<(), AppError> {
+    todo!()
+}
+
+pub async fn delete_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _schedule_id: Uuid,
+) -> Result<(), AppError> {
+    todo!()
+}
+
+pub async fn respond_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _schedule_id: Uuid,
+    _req: RespondScheduleRequest,
+) -> Result<RespondScheduleResponse, AppError> {
+    todo!()
+}
+
+// ============================================================
+// 목록/조회
+// ============================================================
+
+pub async fn get_group_schedules(
+    _pool: &PgPool,
+    _user_id: &str,
+    _group_id: Uuid,
+    _query: GroupScheduleQuery,
+) -> Result<Vec<ScheduleResponse>, AppError> {
+    todo!()
+}
+
+pub async fn get_home_schedules(
+    _pool: &PgPool,
+    _user_id: &str,
+    _query: HomeQuery,
+) -> Result<Vec<ScheduleResponse>, AppError> {
+    todo!()
+}
+
+pub async fn get_calendar_schedules(
+    _pool: &PgPool,
+    _user_id: &str,
+    _query: CalendarQuery,
+) -> Result<Vec<ScheduleResponse>, AppError> {
+    todo!()
+}
+
+pub async fn get_calendar_sync(
+    _pool: &PgPool,
+    _user_id: &str,
+) -> Result<Vec<CalendarSyncSchedule>, AppError> {
+    todo!()
+}
+
+pub async fn check_conflicts(
+    _pool: &PgPool,
+    _user_id: &str,
+    _req: CheckConflictsRequest,
+) -> Result<Vec<ScheduleConflict>, AppError> {
+    todo!()
+}
+
+// ============================================================
+// 반복일정
+// ============================================================
+
+pub async fn create_recurring_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _req: CreateRecurringScheduleRequest,
+) -> Result<CreateRecurringScheduleResponse, AppError> {
+    todo!()
+}
+
+pub async fn get_recurring_schedules(
+    _pool: &PgPool,
+    _user_id: &str,
+) -> Result<Vec<RecurringSchedule>, AppError> {
+    todo!()
+}
+
+pub async fn update_recurring_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _id: Uuid,
+    _req: UpdateRecurringScheduleRequest,
+) -> Result<(), AppError> {
+    todo!()
+}
+
+pub async fn delete_recurring_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _id: Uuid,
+) -> Result<(), AppError> {
+    todo!()
+}

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
+use serde::Deserialize;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -2278,11 +2279,236 @@ pub async fn delete_recurring_schedule(
 // AI 일정 추출
 // ============================================================
 
+/// Prompt injection 방어: 사용자 입력에서 위험한 마커 제거
+fn sanitize_user_data(input: &str) -> String {
+    let without_tags = input
+        .replace("<user-data>", "")
+        .replace("</user-data>", "")
+        .replace("<USER-DATA>", "")
+        .replace("</USER-DATA>", "");
+
+    without_tags
+        .replace("[system]", "")
+        .replace("[/system]", "")
+        .replace("[assistant]", "")
+        .replace("[/assistant]", "")
+        .replace("[user]", "")
+        .replace("[/user]", "")
+        .replace("[SYSTEM]", "")
+        .replace("[/SYSTEM]", "")
+        .replace("[ASSISTANT]", "")
+        .replace("[/ASSISTANT]", "")
+        .replace("[USER]", "")
+        .replace("[/USER]", "")
+}
+
+/// base64 문자열 앞부분에서 MIME 타입 감지
+fn detect_mime_type(base64: &str) -> &'static str {
+    if base64.starts_with("/9j/") {
+        "image/jpeg"
+    } else if base64.starts_with("iVBOR") {
+        "image/png"
+    } else if base64.starts_with("R0lGOD") {
+        "image/gif"
+    } else if base64.starts_with("UklGR") {
+        "image/webp"
+    } else {
+        "image/jpeg"
+    }
+}
+
+/// Gemini 응답에서 마크다운 코드블록을 제거하고 순수 JSON 추출
+fn extract_json_from_response(text: &str) -> String {
+    // ```json ... ``` 또는 ``` ... ``` 패턴 매칭
+    if let Some(start) = text.find("```") {
+        let after_backticks = &text[start + 3..];
+        // "json\n" 접두사 스킵
+        let content_start = if let Some(stripped) = after_backticks.strip_prefix("json") {
+            stripped
+        } else {
+            after_backticks
+        };
+        if let Some(end) = content_start.find("```") {
+            return content_start[..end].trim().to_string();
+        }
+    }
+    text.trim().to_string()
+}
+
+/// Gemini 파싱용 내부 응답 구조체
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Option<Vec<GeminiCandidate>>,
+}
+
+#[derive(Deserialize)]
+struct GeminiCandidate {
+    content: Option<GeminiContent>,
+}
+
+#[derive(Deserialize)]
+struct GeminiContent {
+    parts: Option<Vec<GeminiPart>>,
+}
+
+#[derive(Deserialize)]
+struct GeminiPart {
+    text: Option<String>,
+}
+
+/// Gemini가 반환한 일정 JSON 파싱용
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ParsedSchedule {
+    title: Option<String>,
+    emoji: Option<String>,
+    start_date: Option<String>,
+    end_date: Option<String>,
+    location: Option<String>,
+    address: Option<String>,
+    description: Option<String>,
+    description_blocks: Option<Vec<serde_json::Value>>,
+}
+
+/// description_blocks 필터링 및 인접 text 블록 병합
+fn process_description_blocks(
+    raw_blocks: Vec<serde_json::Value>,
+) -> Option<serde_json::Value> {
+    // 유효한 블록만 필터
+    let valid_blocks: Vec<serde_json::Value> = raw_blocks
+        .into_iter()
+        .filter(|block| {
+            let block_type = block.get("type").and_then(|v| v.as_str());
+            match block_type {
+                Some("text") => block
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|c| !c.is_empty()),
+                Some("checklist" | "bulletList") => block
+                    .get("items")
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                _ => false,
+            }
+        })
+        .collect();
+
+    if valid_blocks.is_empty() {
+        return None;
+    }
+
+    // 인접 text 블록 병합
+    if valid_blocks.len() <= 1 {
+        return Some(serde_json::Value::Array(valid_blocks));
+    }
+
+    let mut merged: Vec<serde_json::Value> = Vec::new();
+    for block in valid_blocks {
+        let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if block_type == "text" {
+            if let Some(last) = merged.last_mut() {
+                let last_type = last.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                if last_type == "text" {
+                    let last_content = last
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let new_content = block
+                        .get("content")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let combined = format!("{}\n\n{}", last_content, new_content);
+                    *last = serde_json::json!({
+                        "type": "text",
+                        "content": combined,
+                    });
+                    continue;
+                }
+            }
+        }
+        merged.push(block);
+    }
+
+    if merged.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Array(merged))
+    }
+}
+
+/// description_blocks에서 plain text description 생성 (하위 호환)
+fn blocks_to_plain_description(blocks: &serde_json::Value) -> Option<String> {
+    let arr = blocks.as_array()?;
+    let parts: Vec<String> = arr
+        .iter()
+        .filter_map(|block| {
+            let block_type = block.get("type").and_then(|v| v.as_str())?;
+            match block_type {
+                "text" => block
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                "checklist" | "bulletList" => {
+                    let items = block.get("items").and_then(|v| v.as_array())?;
+                    let joined: String = items
+                        .iter()
+                        .filter_map(|i| i.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    if joined.is_empty() {
+                        None
+                    } else {
+                        Some(joined)
+                    }
+                }
+                _ => None,
+            }
+        })
+        .collect();
+
+    let result = parts.join("\n").trim().to_string();
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+const SCHEDULE_EXTRACTION_PROMPT: &str = r#"당신은 한국어 문자 메시지 또는 이미지에서 일정 정보를 추출하는 전문가입니다.
+
+입력된 텍스트 또는 이미지에서 다음 정보를 JSON 형태로 추출하세요:
+- title: 일정 제목 (간결하게 추론, 30자 이내)
+- emoji: 일정 내용에 어울리는 이모지 1개 (예: 💼, 🏥, 🎉, 🏃, ☕️)
+- startDate: 시작 날짜시간 (ISO 8601 형식, 예: "2026-03-27T09:00:00+09:00")
+- endDate: 종료 날짜시간 (ISO 8601 형식, 없으면 null)
+- location: 장소명 (없으면 null)
+- address: 상세 주소 (없으면 null)
+- descriptionBlocks: 부가 정보를 구조화된 블록 배열로 분류 (없으면 null)
+  - { type: "text", content: "..." } — 일반 텍스트 정보 (급여, 연락처, 기타 안내)
+  - { type: "checklist", items: ["...", "..."] } — 준비물, 할 일 등 체크 가능한 항목
+  - { type: "bulletList", items: ["...", "..."] } — 나열형 정보 (여러 연락처, 여러 조건 등)
+
+규칙:
+- 반드시 JSON만 출력, 다른 텍스트 절대 금지
+- 연도가 없으면 현재 연도 기준으로 추론
+- "9시~18시" 같은 범위 표현은 startDate/endDate로 분리
+- 장소명과 상세 주소를 구분 (장소: "GS25 성남양우프레시점", 주소: "경기 성남시 수정구 논골로 29")
+- 준비물, 할 일 목록 등 체크 가능한 항목은 type: 'checklist'로 분류
+- 단일 정보(급여, 연락처 등)는 type: 'text'로, 같은 카테고리의 여러 항목 나열은 type: 'bulletList'로 분류
+- descriptionBlocks 하나의 블록에 여러 종류의 정보를 합치지 말고, 정보 종류별로 블록을 분리
+- title은 핵심 내용을 간결하게 (예: "GS25 진열 근무", "고용센터 초기상담")
+- 텍스트 또는 이미지(스크린샷, 포스터, 문자 캡처 등)에서 일정 정보를 추출
+- 이미지인 경우 텍스트를 먼저 인식한 후 동일한 규칙으로 추출
+
+현재 시각: {currentTime}
+"#;
+
 pub async fn extract_schedule(
     _pool: &PgPool,
     _user_id: &str,
     req: ExtractScheduleRequest,
 ) -> Result<ExtractScheduleResponse, AppError> {
+    // 1. 유효성 검사
     if req.text.is_none() && req.image_base64.is_none() {
         return Err(AppError::BadRequest(
             "text 또는 image_base64 중 하나는 필요합니다".to_string(),
@@ -2297,9 +2523,154 @@ pub async fn extract_schedule(
         }
     }
 
-    parse_timezone(req.timezone.as_deref())?;
+    if let Some(image_base64) = &req.image_base64 {
+        if image_base64.len() > 5_300_000 {
+            return Err(AppError::BadRequest(
+                "이미지 크기가 너무 큽니다 (최대 4MB)".to_string(),
+            ));
+        }
+    }
 
-    Err(AppError::BadRequest(
-        "일정 추출 기능은 아직 지원되지 않습니다".to_string(),
-    ))
+    // 2. API 키 확인
+    let api_key = std::env::var("GEMINI_API_KEY").map_err(|_| {
+        AppError::BadRequest("일정 추출 기능이 설정되지 않았습니다".to_string())
+    })?;
+
+    if api_key.is_empty() {
+        return Err(AppError::BadRequest(
+            "일정 추출 기능이 설정되지 않았습니다".to_string(),
+        ));
+    }
+
+    // 3. timezone 검증 및 현재 시각 계산
+    let safe_timezone: Tz = req
+        .timezone
+        .as_deref()
+        .unwrap_or("Asia/Seoul")
+        .parse::<Tz>()
+        .unwrap_or(chrono_tz::Asia::Seoul);
+
+    let now = Utc::now().with_timezone(&safe_timezone);
+    let current_time = now.format("%Y년 %m월 %d일 %A %H:%M").to_string();
+
+    let prompt = SCHEDULE_EXTRACTION_PROMPT.replace("{currentTime}", &current_time);
+
+    // 4. 입력 데이터 준비
+    let sanitized_text = req.text.as_ref().map(|t| sanitize_user_data(t.trim()));
+
+    // 5. Gemini API 요청 구성
+    let mut parts = Vec::new();
+
+    // 프롬프트
+    parts.push(serde_json::json!({ "text": prompt }));
+
+    // 이미지가 있으면 inlineData 추가
+    if let Some(image_base64) = &req.image_base64 {
+        let mime_type = detect_mime_type(image_base64);
+        parts.push(serde_json::json!({
+            "inlineData": {
+                "mimeType": mime_type,
+                "data": image_base64,
+            }
+        }));
+    }
+
+    // 텍스트가 있으면 user-data 태그로 추가
+    if let Some(sanitized) = &sanitized_text {
+        parts.push(serde_json::json!({
+            "text": format!("<user-data>{}</user-data>", sanitized)
+        }));
+    }
+
+    let request_body = serde_json::json!({
+        "contents": [{
+            "parts": parts
+        }]
+    });
+
+    // 6. Gemini API 호출
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={}",
+        api_key
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("Gemini API request failed: {}", e);
+            AppError::Internal("일정 추출에 실패했습니다".to_string())
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        tracing::error!("Gemini API error: status={}, body={}", status, body);
+        return Err(AppError::Internal(
+            "일정 추출에 실패했습니다".to_string(),
+        ));
+    }
+
+    let gemini_response: GeminiResponse = response.json().await.map_err(|e| {
+        tracing::error!("Failed to parse Gemini response: {}", e);
+        AppError::Internal("일정 추출에 실패했습니다".to_string())
+    })?;
+
+    // 7. 응답 텍스트 추출
+    let response_text = gemini_response
+        .candidates
+        .as_ref()
+        .and_then(|c| c.first())
+        .and_then(|c| c.content.as_ref())
+        .and_then(|c| c.parts.as_ref())
+        .and_then(|p| p.first())
+        .and_then(|p| p.text.as_ref())
+        .ok_or_else(|| {
+            tracing::error!("Gemini response has no text content");
+            AppError::Internal("일정 추출에 실패했습니다".to_string())
+        })?;
+
+    // 8. JSON 파싱
+    let json_text = extract_json_from_response(response_text);
+    let parsed: ParsedSchedule = serde_json::from_str(&json_text).map_err(|e| {
+        tracing::error!(
+            "Failed to parse schedule JSON: {}, raw: {}",
+            e,
+            &json_text[..json_text.len().min(200)]
+        );
+        AppError::Internal("일정 추출에 실패했습니다".to_string())
+    })?;
+
+    // 9. description_blocks 처리
+    let description_blocks = parsed
+        .description_blocks
+        .and_then(process_description_blocks);
+
+    // 10. description 생성 (하위 호환)
+    let description = if let Some(ref blocks) = description_blocks {
+        blocks_to_plain_description(blocks)
+    } else {
+        parsed.description
+    };
+
+    tracing::info!(
+        "Extracted schedule: title={:?}, start={:?}",
+        parsed.title,
+        parsed.start_date
+    );
+
+    Ok(ExtractScheduleResponse {
+        title: parsed.title,
+        emoji: parsed.emoji,
+        start_date: parsed.start_date,
+        end_date: parsed.end_date,
+        location: parsed.location,
+        address: parsed.address,
+        description,
+        description_blocks,
+    })
 }

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -1,3 +1,4 @@
+use chrono::{Datelike, Duration, NaiveDate, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -5,49 +6,805 @@ use crate::errors::AppError;
 use crate::models::schedule::*;
 
 // ============================================================
+// 헬퍼
+// ============================================================
+
+/// 제목 유효성 검증: trim, 비어있지 않음, 최대 30자
+fn validate_title(title: &str) -> Result<String, AppError> {
+    let trimmed = title.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest(
+            "제목은 비어있을 수 없습니다".to_string(),
+        ));
+    }
+    if trimmed.chars().count() > 30 {
+        return Err(AppError::BadRequest(
+            "제목은 30자 이하여야 합니다".to_string(),
+        ));
+    }
+    Ok(trimmed)
+}
+
+/// 설명 유효성 검증: 최대 500자
+fn validate_description(description: &Option<String>) -> Result<(), AppError> {
+    if let Some(desc) = description {
+        if desc.chars().count() > 500 {
+            return Err(AppError::BadRequest(
+                "설명은 500자 이하여야 합니다".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Schedule DB 행 + votes로 ScheduleResponse 빌드
+fn build_schedule_response(schedule: &Schedule, votes: Vec<ScheduleVote>) -> ScheduleResponse {
+    let location = schedule.location_name.as_ref().map(|name| LocationResponse {
+        name: name.clone(),
+        address: schedule.location_address.clone(),
+        latitude: schedule.location_latitude,
+        longitude: schedule.location_longitude,
+    });
+
+    let is_group = schedule.schedule_type == ScheduleType::Group;
+
+    let votes_response = if is_group {
+        let accepted: Vec<String> = votes
+            .iter()
+            .filter(|v| v.status == VoteStatus::Accepted)
+            .map(|v| v.user_id.clone())
+            .collect();
+        let declined: Vec<String> = votes
+            .iter()
+            .filter(|v| v.status == VoteStatus::Declined)
+            .map(|v| v.user_id.clone())
+            .collect();
+        Some(VotesResponse { accepted, declined })
+    } else {
+        None
+    };
+
+    ScheduleResponse {
+        id: schedule.id,
+        schedule_type: schedule.schedule_type.clone(),
+        user_id: schedule.user_id.clone(),
+        title: schedule.title.clone(),
+        emoji: schedule.emoji.clone(),
+        description: schedule.description.clone(),
+        description_blocks: schedule.description_blocks.clone(),
+        start_at: schedule.start_at,
+        end_at: schedule.end_at,
+        location,
+        created_at: schedule.created_at,
+        updated_at: schedule.updated_at,
+        // 그룹일정 전용
+        group_id: if is_group { schedule.group_id } else { None },
+        host_id: if is_group {
+            Some(schedule.user_id.clone())
+        } else {
+            None
+        },
+        minimum_participants: if is_group {
+            schedule.minimum_participants
+        } else {
+            None
+        },
+        is_confirmed: if is_group {
+            schedule.is_confirmed
+        } else {
+            None
+        },
+        vote_deadline: if is_group {
+            schedule.vote_deadline
+        } else {
+            None
+        },
+        tracking_start_minutes_before: if is_group {
+            schedule.tracking_start_minutes_before
+        } else {
+            None
+        },
+        image_urls: if is_group {
+            schedule.image_urls.clone()
+        } else {
+            None
+        },
+        votes: votes_response,
+        // 개인일정 전용
+        reminder_minutes_before: if !is_group {
+            schedule.reminder_minutes_before
+        } else {
+            None
+        },
+    }
+}
+
+// ============================================================
 // 그룹/개인 일정 CRUD
 // ============================================================
 
 pub async fn create_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _req: CreateScheduleRequest,
+    pool: &PgPool,
+    user_id: &str,
+    req: CreateScheduleRequest,
 ) -> Result<CreateScheduleResponse, AppError> {
-    todo!()
+    // 공통 검증
+    let title = validate_title(&req.title)?;
+    validate_description(&req.description)?;
+
+    // end_at > start_at 검증 (strictly greater, equal is invalid)
+    if let Some(end_at) = req.end_at {
+        if end_at <= req.start_at {
+            return Err(AppError::BadRequest(
+                "종료 시간은 시작 시간 이후여야 합니다".to_string(),
+            ));
+        }
+    }
+
+    match req.schedule_type {
+        ScheduleType::Group => {
+            // 그룹일정 전용 검증
+            let group_id = req.group_id.ok_or_else(|| {
+                AppError::BadRequest("그룹 일정에는 group_id가 필요합니다".to_string())
+            })?;
+
+            let minimum_participants = req.minimum_participants.ok_or_else(|| {
+                AppError::BadRequest(
+                    "그룹 일정에는 minimum_participants가 필요합니다".to_string(),
+                )
+            })?;
+
+            if minimum_participants < 1 {
+                return Err(AppError::BadRequest(
+                    "최소 참여 인원은 1명 이상이어야 합니다".to_string(),
+                ));
+            }
+
+            // description_blocks 최대 20
+            if let Some(ref blocks) = req.description_blocks {
+                if let Some(arr) = blocks.as_array() {
+                    if arr.len() > 20 {
+                        return Err(AppError::BadRequest(
+                            "설명 블록은 최대 20개까지 허용됩니다".to_string(),
+                        ));
+                    }
+                }
+            }
+
+            // image_urls 최대 3
+            if let Some(ref urls) = req.image_urls {
+                if urls.len() > 3 {
+                    return Err(AppError::BadRequest(
+                        "이미지는 최대 3개까지 허용됩니다".to_string(),
+                    ));
+                }
+            }
+
+            // 그룹 존재 확인
+            let group_exists =
+                sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
+                    .bind(group_id)
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            if group_exists.is_none() {
+                return Err(AppError::NotFound(
+                    "그룹을 찾을 수 없습니다".to_string(),
+                ));
+            }
+
+            // 멤버십 확인
+            let membership = sqlx::query_as::<_, (String,)>(
+                "SELECT user_id FROM group_members WHERE group_id = $1 AND user_id = $2",
+            )
+            .bind(group_id)
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            if membership.is_none() {
+                return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
+            }
+
+            // is_confirmed: minimum_participants <= 1 이면 호스트 자동수락으로 즉시 확정
+            let is_confirmed = minimum_participants <= 1;
+            let vote_deadline = req.start_at;
+
+            // 트랜잭션: INSERT schedule + INSERT host vote
+            let mut tx = pool
+                .begin()
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            let location_name = req.location.as_ref().map(|l| l.name.clone());
+            let location_address = req.location.as_ref().and_then(|l| l.address.clone());
+            let location_latitude = req.location.as_ref().and_then(|l| l.latitude);
+            let location_longitude = req.location.as_ref().and_then(|l| l.longitude);
+
+            let schedule = sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (schedule_type, user_id, title, emoji, description, \
+                 description_blocks, start_at, end_at, location_name, location_address, \
+                 location_latitude, location_longitude, group_id, minimum_participants, \
+                 is_confirmed, vote_deadline, tracking_start_minutes_before, image_urls) \
+                 VALUES ('group'::schedule_type, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, \
+                         $12, $13, $14, $15, $16, $17) \
+                 RETURNING *",
+            )
+            .bind(user_id)
+            .bind(&title)
+            .bind(&req.emoji)
+            .bind(&req.description)
+            .bind(&req.description_blocks)
+            .bind(req.start_at)
+            .bind(req.end_at)
+            .bind(&location_name)
+            .bind(&location_address)
+            .bind(location_latitude)
+            .bind(location_longitude)
+            .bind(group_id)
+            .bind(minimum_participants)
+            .bind(is_confirmed)
+            .bind(vote_deadline)
+            .bind(req.tracking_start_minutes_before)
+            .bind(&req.image_urls)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            // P16: 호스트를 accepted로 schedule_votes에 등록
+            sqlx::query(
+                "INSERT INTO schedule_votes (schedule_id, user_id, status) \
+                 VALUES ($1, $2, 'accepted'::vote_status)",
+            )
+            .bind(schedule.id)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            tx.commit()
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            Ok(CreateScheduleResponse {
+                schedule_id: schedule.id,
+                title: schedule.title,
+                group_id: schedule.group_id,
+                start_at: schedule.start_at,
+                is_confirmed: schedule.is_confirmed,
+            })
+        }
+        ScheduleType::Personal => {
+            // 개인일정: group_id가 있으면 에러
+            if req.group_id.is_some() {
+                return Err(AppError::BadRequest(
+                    "개인 일정에는 group_id를 설정할 수 없습니다".to_string(),
+                ));
+            }
+
+            let location_name = req.location.as_ref().map(|l| l.name.clone());
+            let location_address = req.location.as_ref().and_then(|l| l.address.clone());
+            let location_latitude = req.location.as_ref().and_then(|l| l.latitude);
+            let location_longitude = req.location.as_ref().and_then(|l| l.longitude);
+
+            let schedule = sqlx::query_as::<_, Schedule>(
+                "INSERT INTO schedules (schedule_type, user_id, title, emoji, description, \
+                 description_blocks, start_at, end_at, location_name, location_address, \
+                 location_latitude, location_longitude, reminder_minutes_before) \
+                 VALUES ('personal'::schedule_type, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, \
+                         $11, $12) \
+                 RETURNING *",
+            )
+            .bind(user_id)
+            .bind(&title)
+            .bind(&req.emoji)
+            .bind(&req.description)
+            .bind(&req.description_blocks)
+            .bind(req.start_at)
+            .bind(req.end_at)
+            .bind(&location_name)
+            .bind(&location_address)
+            .bind(location_latitude)
+            .bind(location_longitude)
+            .bind(req.reminder_minutes_before)
+            .fetch_one(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            Ok(CreateScheduleResponse {
+                schedule_id: schedule.id,
+                title: schedule.title,
+                group_id: None,
+                start_at: schedule.start_at,
+                is_confirmed: None,
+            })
+        }
+    }
 }
 
 pub async fn get_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _schedule_id: Uuid,
+    pool: &PgPool,
+    user_id: &str,
+    schedule_id: Uuid,
 ) -> Result<ScheduleResponse, AppError> {
-    todo!()
+    // 일정 조회
+    let schedule = sqlx::query_as::<_, Schedule>("SELECT * FROM schedules WHERE id = $1")
+        .bind(schedule_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("일정을 찾을 수 없습니다".to_string()))?;
+
+    // 권한 확인
+    match schedule.schedule_type {
+        ScheduleType::Group => {
+            let group_id = schedule.group_id.ok_or_else(|| {
+                AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
+            })?;
+
+            let membership = sqlx::query_as::<_, (String,)>(
+                "SELECT user_id FROM group_members WHERE group_id = $1 AND user_id = $2",
+            )
+            .bind(group_id)
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            if membership.is_none() {
+                return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
+            }
+        }
+        ScheduleType::Personal => {
+            if schedule.user_id != user_id {
+                return Err(AppError::Forbidden(
+                    "본인의 일정만 조회할 수 있습니다".to_string(),
+                ));
+            }
+        }
+    }
+
+    // 투표 조회
+    let votes = sqlx::query_as::<_, ScheduleVote>(
+        "SELECT schedule_id, user_id, status, responded_at \
+         FROM schedule_votes WHERE schedule_id = $1",
+    )
+    .bind(schedule_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(build_schedule_response(&schedule, votes))
 }
 
 pub async fn update_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _schedule_id: Uuid,
-    _req: UpdateScheduleRequest,
+    pool: &PgPool,
+    user_id: &str,
+    schedule_id: Uuid,
+    req: UpdateScheduleRequest,
 ) -> Result<(), AppError> {
-    todo!()
+    // 일정 조회
+    let schedule = sqlx::query_as::<_, Schedule>("SELECT * FROM schedules WHERE id = $1")
+        .bind(schedule_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("일정을 찾을 수 없습니다".to_string()))?;
+
+    // 권한 확인
+    match schedule.schedule_type {
+        ScheduleType::Group => {
+            // P10: 일정 호스트 OR 그룹 관리자
+            if schedule.user_id != user_id {
+                let group_id = schedule.group_id.ok_or_else(|| {
+                    AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
+                })?;
+
+                let role_row = sqlx::query_as::<_, (String,)>(
+                    "SELECT role::TEXT FROM group_members WHERE group_id = $1 AND user_id = $2",
+                )
+                .bind(group_id)
+                .bind(user_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+                match role_row {
+                    Some((role,)) if role == "admin" => { /* OK: 그룹 관리자 */ }
+                    _ => {
+                        return Err(AppError::Forbidden(
+                            "일정 호스트 또는 그룹 관리자만 수정할 수 있습니다".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        ScheduleType::Personal => {
+            if schedule.user_id != user_id {
+                return Err(AppError::Forbidden(
+                    "본인의 일정만 수정할 수 있습니다".to_string(),
+                ));
+            }
+        }
+    }
+
+    // P12: start_at이 미래여야 함
+    if schedule.start_at <= Utc::now() {
+        return Err(AppError::PreconditionFailed(
+            "이미 시작된 일정은 수정할 수 없습니다".to_string(),
+        ));
+    }
+
+    // 제목 검증
+    if let Some(ref title) = req.title {
+        validate_title(title)?;
+    }
+
+    // 동적 UPDATE 쿼리 빌드
+    let mut set_clauses: Vec<String> = Vec::new();
+    let mut param_index = 1u32;
+
+    if req.title.is_some() {
+        set_clauses.push(format!("title = ${param_index}"));
+        param_index += 1;
+    }
+    if req.emoji.is_some() {
+        set_clauses.push(format!("emoji = ${param_index}"));
+        param_index += 1;
+    }
+    if req.description.is_some() {
+        set_clauses.push(format!("description = ${param_index}"));
+        param_index += 1;
+    }
+    if req.description_blocks.is_some() {
+        set_clauses.push(format!("description_blocks = ${param_index}"));
+        param_index += 1;
+    }
+    if req.start_at.is_some() {
+        set_clauses.push(format!("start_at = ${param_index}"));
+        param_index += 1;
+        // P30: start_at 변경 시 vote_deadline도 동기화
+        if schedule.schedule_type == ScheduleType::Group {
+            set_clauses.push(format!("vote_deadline = ${param_index}"));
+            param_index += 1;
+        }
+    }
+    if req.end_at.is_some() {
+        set_clauses.push(format!("end_at = ${param_index}"));
+        param_index += 1;
+    }
+    if req.location.is_some() {
+        set_clauses.push(format!("location_name = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_address = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_latitude = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_longitude = ${param_index}"));
+        param_index += 1;
+    }
+    if req.minimum_participants.is_some() {
+        set_clauses.push(format!("minimum_participants = ${param_index}"));
+        param_index += 1;
+    }
+    if req.tracking_start_minutes_before.is_some() {
+        set_clauses.push(format!("tracking_start_minutes_before = ${param_index}"));
+        param_index += 1;
+    }
+    if req.image_urls.is_some() {
+        set_clauses.push(format!("image_urls = ${param_index}"));
+        param_index += 1;
+    }
+    if req.reminder_minutes_before.is_some() {
+        set_clauses.push(format!("reminder_minutes_before = ${param_index}"));
+        param_index += 1;
+    }
+
+    if set_clauses.is_empty() {
+        return Ok(());
+    }
+
+    set_clauses.push("updated_at = NOW()".to_string());
+
+    let sql = format!(
+        "UPDATE schedules SET {} WHERE id = ${param_index}",
+        set_clauses.join(", "),
+    );
+
+    let mut query = sqlx::query(&sql);
+
+    // 바인딩 순서: set_clauses 추가 순서와 동일
+    if let Some(ref title) = req.title {
+        query = query.bind(title.trim().to_string());
+    }
+    if let Some(ref inner) = req.emoji {
+        match inner {
+            None => query = query.bind(None::<String>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(ref inner) = req.description {
+        match inner {
+            None => query = query.bind(None::<String>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(ref inner) = req.description_blocks {
+        match inner {
+            None => query = query.bind(None::<serde_json::Value>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(start_at) = req.start_at {
+        query = query.bind(start_at);
+        // P30: vote_deadline도 같은 값으로 바인딩
+        if schedule.schedule_type == ScheduleType::Group {
+            query = query.bind(start_at);
+        }
+    }
+    if let Some(ref inner) = req.end_at {
+        match inner {
+            None => query = query.bind(None::<chrono::DateTime<Utc>>),
+            Some(v) => query = query.bind(Some(*v)),
+        }
+    }
+    if let Some(ref inner) = req.location {
+        match inner {
+            None => {
+                query = query.bind(None::<String>);
+                query = query.bind(None::<String>);
+                query = query.bind(None::<f64>);
+                query = query.bind(None::<f64>);
+            }
+            Some(loc) => {
+                query = query.bind(Some(loc.name.clone()));
+                query = query.bind(loc.address.clone());
+                query = query.bind(loc.latitude);
+                query = query.bind(loc.longitude);
+            }
+        }
+    }
+    if let Some(min_p) = req.minimum_participants {
+        query = query.bind(min_p);
+    }
+    if let Some(ref inner) = req.tracking_start_minutes_before {
+        match inner {
+            None => query = query.bind(None::<i16>),
+            Some(v) => query = query.bind(Some(*v)),
+        }
+    }
+    if let Some(ref inner) = req.image_urls {
+        match inner {
+            None => query = query.bind(None::<Vec<String>>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(ref inner) = req.reminder_minutes_before {
+        match inner {
+            None => query = query.bind(None::<i16>),
+            Some(v) => query = query.bind(Some(*v)),
+        }
+    }
+
+    // WHERE id = $N
+    query = query.bind(schedule_id);
+
+    query
+        .execute(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(())
 }
 
 pub async fn delete_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _schedule_id: Uuid,
+    pool: &PgPool,
+    user_id: &str,
+    schedule_id: Uuid,
 ) -> Result<(), AppError> {
-    todo!()
+    // 일정 조회
+    let schedule = sqlx::query_as::<_, Schedule>("SELECT * FROM schedules WHERE id = $1")
+        .bind(schedule_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("일정을 찾을 수 없습니다".to_string()))?;
+
+    // P11: 권한 확인 (update와 동일)
+    match schedule.schedule_type {
+        ScheduleType::Group => {
+            if schedule.user_id != user_id {
+                let group_id = schedule.group_id.ok_or_else(|| {
+                    AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
+                })?;
+
+                let role_row = sqlx::query_as::<_, (String,)>(
+                    "SELECT role::TEXT FROM group_members WHERE group_id = $1 AND user_id = $2",
+                )
+                .bind(group_id)
+                .bind(user_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+                match role_row {
+                    Some((role,)) if role == "admin" => { /* OK: 그룹 관리자 */ }
+                    _ => {
+                        return Err(AppError::Forbidden(
+                            "일정 호스트 또는 그룹 관리자만 삭제할 수 있습니다".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        ScheduleType::Personal => {
+            if schedule.user_id != user_id {
+                return Err(AppError::Forbidden(
+                    "본인의 일정만 삭제할 수 있습니다".to_string(),
+                ));
+            }
+        }
+    }
+
+    // P13: start_at이 미래여야 함
+    if schedule.start_at <= Utc::now() {
+        return Err(AppError::PreconditionFailed(
+            "이미 시작된 일정은 삭제할 수 없습니다".to_string(),
+        ));
+    }
+
+    // DELETE (CASCADE removes schedule_votes)
+    sqlx::query("DELETE FROM schedules WHERE id = $1")
+        .bind(schedule_id)
+        .execute(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(())
 }
 
 pub async fn respond_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _schedule_id: Uuid,
-    _req: RespondScheduleRequest,
+    pool: &PgPool,
+    user_id: &str,
+    schedule_id: Uuid,
+    req: RespondScheduleRequest,
 ) -> Result<RespondScheduleResponse, AppError> {
-    todo!()
+    // status 검증
+    let status = req.status.trim().to_lowercase();
+    if status != "accepted" && status != "declined" && status != "pending" {
+        return Err(AppError::BadRequest(
+            "상태는 accepted, declined, pending 중 하나여야 합니다".to_string(),
+        ));
+    }
+
+    // 일정 조회
+    let schedule = sqlx::query_as::<_, Schedule>("SELECT * FROM schedules WHERE id = $1")
+        .bind(schedule_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("일정을 찾을 수 없습니다".to_string()))?;
+
+    // 그룹 일정만 응답 가능
+    if schedule.schedule_type != ScheduleType::Group {
+        return Err(AppError::BadRequest(
+            "개인 일정에는 응답할 수 없습니다".to_string(),
+        ));
+    }
+
+    let group_id = schedule.group_id.ok_or_else(|| {
+        AppError::Internal("그룹 일정에 group_id가 없습니다".to_string())
+    })?;
+
+    // 멤버십 확인
+    let membership = sqlx::query_as::<_, (String,)>(
+        "SELECT user_id FROM group_members WHERE group_id = $1 AND user_id = $2",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if membership.is_none() {
+        return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
+    }
+
+    // 트랜잭션
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if status == "pending" {
+        // P28: pending이면 투표 삭제
+        sqlx::query(
+            "DELETE FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2",
+        )
+        .bind(schedule_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    } else {
+        // P27: 이미 같은 상태면 no-op
+        let current_vote = sqlx::query_as::<_, (String,)>(
+            "SELECT status::TEXT FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2",
+        )
+        .bind(schedule_id)
+        .bind(user_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        let already_same = current_vote
+            .as_ref()
+            .is_some_and(|(s,)| s == &status);
+
+        if !already_same {
+            // UPSERT: INSERT ON CONFLICT UPDATE
+            sqlx::query(
+                "INSERT INTO schedule_votes (schedule_id, user_id, status, responded_at) \
+                 VALUES ($1, $2, $3::vote_status, NOW()) \
+                 ON CONFLICT (schedule_id, user_id) \
+                 DO UPDATE SET status = $3::vote_status, responded_at = NOW()",
+            )
+            .bind(schedule_id)
+            .bind(user_id)
+            .bind(&status)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        }
+    }
+
+    // P29: is_confirmed 재계산
+    let minimum_participants = schedule.minimum_participants.unwrap_or(1);
+    let accepted_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM schedule_votes \
+         WHERE schedule_id = $1 AND status = 'accepted'::vote_status",
+    )
+    .bind(schedule_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let new_is_confirmed = accepted_count.0 >= minimum_participants as i64;
+
+    sqlx::query("UPDATE schedules SET is_confirmed = $1 WHERE id = $2")
+        .bind(new_is_confirmed)
+        .bind(schedule_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // confirmed_schedule 빌드 (is_confirmed && status == "accepted")
+    let confirmed_schedule = if new_is_confirmed && status == "accepted" {
+        Some(CalendarSyncSchedule {
+            id: schedule.id,
+            title: schedule.title.clone(),
+            emoji: schedule.emoji.clone(),
+            start_at: schedule.start_at,
+            end_at: schedule.end_at,
+            location: schedule.location_name.clone(),
+            group_id,
+        })
+    } else {
+        None
+    };
+
+    Ok(RespondScheduleResponse {
+        schedule_id,
+        status,
+        is_confirmed: new_is_confirmed,
+        confirmed_schedule,
+    })
 }
 
 // ============================================================
@@ -55,43 +812,661 @@ pub async fn respond_schedule(
 // ============================================================
 
 pub async fn get_group_schedules(
-    _pool: &PgPool,
-    _user_id: &str,
-    _group_id: Uuid,
-    _query: GroupScheduleQuery,
+    pool: &PgPool,
+    user_id: &str,
+    group_id: Uuid,
+    query: GroupScheduleQuery,
 ) -> Result<PaginatedScheduleResponse, AppError> {
-    todo!()
+    // 그룹 존재 확인
+    let group_exists =
+        sqlx::query_as::<_, (Uuid,)>("SELECT id FROM groups WHERE id = $1")
+            .bind(group_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if group_exists.is_none() {
+        return Err(AppError::NotFound(
+            "그룹을 찾을 수 없습니다".to_string(),
+        ));
+    }
+
+    // 멤버십 확인
+    let membership = sqlx::query_as::<_, (String,)>(
+        "SELECT user_id FROM group_members WHERE group_id = $1 AND user_id = $2",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if membership.is_none() {
+        return Err(AppError::Forbidden("그룹 멤버가 아닙니다".to_string()));
+    }
+
+    let status = query.status.as_deref().unwrap_or("active");
+    let limit = query.limit.unwrap_or(20);
+    let now = Utc::now();
+
+    let schedules = match status {
+        "past" => {
+            match query.cursor {
+                Some(cursor) => {
+                    sqlx::query_as::<_, Schedule>(
+                        "SELECT * FROM schedules \
+                         WHERE group_id = $1 AND schedule_type = 'group' \
+                           AND start_at < $2 AND start_at < $3 \
+                         ORDER BY start_at DESC \
+                         LIMIT $4",
+                    )
+                    .bind(group_id)
+                    .bind(now)
+                    .bind(cursor)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await
+                    .map_err(|e| AppError::Internal(e.to_string()))?
+                }
+                None => {
+                    sqlx::query_as::<_, Schedule>(
+                        "SELECT * FROM schedules \
+                         WHERE group_id = $1 AND schedule_type = 'group' \
+                           AND start_at < $2 \
+                         ORDER BY start_at DESC \
+                         LIMIT $3",
+                    )
+                    .bind(group_id)
+                    .bind(now)
+                    .bind(limit)
+                    .fetch_all(pool)
+                    .await
+                    .map_err(|e| AppError::Internal(e.to_string()))?
+                }
+            }
+        }
+        _ => {
+            // "active": start_at >= NOW(), ASC
+            sqlx::query_as::<_, Schedule>(
+                "SELECT * FROM schedules \
+                 WHERE group_id = $1 AND schedule_type = 'group' \
+                   AND start_at >= $2 \
+                 ORDER BY start_at ASC \
+                 LIMIT $3",
+            )
+            .bind(group_id)
+            .bind(now)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        }
+    };
+
+    // 각 일정의 투표 정보 조회
+    let mut data: Vec<ScheduleResponse> = Vec::with_capacity(schedules.len());
+    for schedule in &schedules {
+        let votes = sqlx::query_as::<_, ScheduleVote>(
+            "SELECT schedule_id, user_id, status, responded_at \
+             FROM schedule_votes WHERE schedule_id = $1",
+        )
+        .bind(schedule.id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        data.push(build_schedule_response(schedule, votes));
+    }
+
+    // 커서: 반환된 항목이 limit개이면 마지막 항목의 start_at
+    let cursor = if schedules.len() as i64 >= limit {
+        schedules.last().map(|s| s.start_at)
+    } else {
+        None
+    };
+
+    Ok(PaginatedScheduleResponse { data, cursor })
 }
 
 pub async fn get_home_schedules(
-    _pool: &PgPool,
-    _user_id: &str,
-    _query: HomeQuery,
+    pool: &PgPool,
+    user_id: &str,
+    query: HomeQuery,
 ) -> Result<Vec<ScheduleResponse>, AppError> {
-    todo!()
+    let limit = query.limit.unwrap_or(20);
+    let now = Utc::now();
+
+    // 유저가 속한 그룹 ID 목록
+    let group_ids: Vec<Uuid> = sqlx::query_as::<_, (Uuid,)>(
+        "SELECT group_id FROM group_members WHERE user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .into_iter()
+    .map(|(id,)| id)
+    .collect();
+
+    if group_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 그룹일정 중 미래 일정 조회
+    let schedules = sqlx::query_as::<_, Schedule>(
+        "SELECT * FROM schedules \
+         WHERE schedule_type = 'group' \
+           AND group_id = ANY($1) \
+           AND start_at >= $2 \
+         ORDER BY start_at ASC \
+         LIMIT $3",
+    )
+    .bind(&group_ids)
+    .bind(now)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut result: Vec<ScheduleResponse> = Vec::with_capacity(schedules.len());
+    for schedule in &schedules {
+        let votes = sqlx::query_as::<_, ScheduleVote>(
+            "SELECT schedule_id, user_id, status, responded_at \
+             FROM schedule_votes WHERE schedule_id = $1",
+        )
+        .bind(schedule.id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        result.push(build_schedule_response(schedule, votes));
+    }
+
+    Ok(result)
 }
 
 pub async fn get_calendar_schedules(
-    _pool: &PgPool,
-    _user_id: &str,
-    _query: CalendarQuery,
+    pool: &PgPool,
+    user_id: &str,
+    query: CalendarQuery,
 ) -> Result<CalendarResponse, AppError> {
-    todo!()
+    let accepted_only = query.accepted_only.unwrap_or(false);
+
+    // 유저가 속한 그룹 ID 목록
+    let group_ids: Vec<Uuid> = sqlx::query_as::<_, (Uuid,)>(
+        "SELECT group_id FROM group_members WHERE user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .into_iter()
+    .map(|(id,)| id)
+    .collect();
+
+    // 그룹일정 조회 (date range)
+    let group_schedules = if group_ids.is_empty() {
+        Vec::new()
+    } else if accepted_only {
+        // 유저가 accepted한 일정만
+        sqlx::query_as::<_, Schedule>(
+            "SELECT s.* FROM schedules s \
+             JOIN schedule_votes sv ON s.id = sv.schedule_id \
+             WHERE s.schedule_type = 'group' \
+               AND s.group_id = ANY($1) \
+               AND s.start_at < $2 \
+               AND (s.end_at > $3 OR s.end_at IS NULL) \
+               AND sv.user_id = $4 \
+               AND sv.status = 'accepted' \
+             ORDER BY s.start_at ASC",
+        )
+        .bind(&group_ids)
+        .bind(query.end)
+        .bind(query.start)
+        .bind(user_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    } else {
+        sqlx::query_as::<_, Schedule>(
+            "SELECT * FROM schedules \
+             WHERE schedule_type = 'group' \
+               AND group_id = ANY($1) \
+               AND start_at < $2 \
+               AND (end_at > $3 OR end_at IS NULL) \
+             ORDER BY start_at ASC",
+        )
+        .bind(&group_ids)
+        .bind(query.end)
+        .bind(query.start)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    };
+
+    // 개인일정 조회 (date range)
+    let personal_schedules = sqlx::query_as::<_, Schedule>(
+        "SELECT * FROM schedules \
+         WHERE schedule_type = 'personal' \
+           AND user_id = $1 \
+           AND start_at < $2 \
+           AND (end_at > $3 OR end_at IS NULL) \
+         ORDER BY start_at ASC",
+    )
+    .bind(user_id)
+    .bind(query.end)
+    .bind(query.start)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // ScheduleResponse 빌드
+    let mut schedules_response: Vec<ScheduleResponse> = Vec::new();
+
+    for schedule in &group_schedules {
+        let votes = sqlx::query_as::<_, ScheduleVote>(
+            "SELECT schedule_id, user_id, status, responded_at \
+             FROM schedule_votes WHERE schedule_id = $1",
+        )
+        .bind(schedule.id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        schedules_response.push(build_schedule_response(schedule, votes));
+    }
+
+    for schedule in &personal_schedules {
+        schedules_response.push(build_schedule_response(schedule, Vec::new()));
+    }
+
+    // 반복일정 확장
+    let recurring_schedules = sqlx::query_as::<_, RecurringSchedule>(
+        "SELECT id, user_id, title, emoji, description, \
+         start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
+         location_name, location_address, location_latitude, location_longitude, \
+         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         days_of_week, day_of_month, \
+         series_start_date, series_end_date, excluded_dates, overrides, \
+         created_at, updated_at \
+         FROM recurring_schedules WHERE user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let range_start = query.start.date_naive();
+    let range_end = query.end.date_naive();
+
+    let mut recurring_instances: Vec<RecurringInstance> = Vec::new();
+    for rs in &recurring_schedules {
+        let mut instances = expand_recurring_in_range(rs, range_start, range_end);
+        recurring_instances.append(&mut instances);
+    }
+
+    Ok(CalendarResponse {
+        schedules: schedules_response,
+        recurring_instances,
+    })
 }
 
 pub async fn get_calendar_sync(
-    _pool: &PgPool,
-    _user_id: &str,
+    pool: &PgPool,
+    user_id: &str,
 ) -> Result<Vec<CalendarSyncSchedule>, AppError> {
-    todo!()
+    let now = Utc::now();
+
+    // 확정된 미래 그룹일정 중 유저가 accepted한 것만
+    let rows = sqlx::query_as::<_, Schedule>(
+        "SELECT s.* FROM schedules s \
+         JOIN schedule_votes sv ON s.id = sv.schedule_id \
+         WHERE s.schedule_type = 'group' \
+           AND s.is_confirmed = TRUE \
+           AND sv.user_id = $1 \
+           AND sv.status = 'accepted' \
+           AND s.start_at >= $2 \
+         ORDER BY s.start_at ASC \
+         LIMIT 50",
+    )
+    .bind(user_id)
+    .bind(now)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let result: Vec<CalendarSyncSchedule> = rows
+        .into_iter()
+        .map(|s| {
+            let group_id = s.group_id.unwrap_or_default();
+            CalendarSyncSchedule {
+                id: s.id,
+                title: s.title,
+                emoji: s.emoji,
+                start_at: s.start_at,
+                end_at: s.end_at,
+                location: s.location_name,
+                group_id,
+            }
+        })
+        .collect();
+
+    Ok(result)
 }
 
 pub async fn check_conflicts(
-    _pool: &PgPool,
-    _user_id: &str,
-    _req: CheckConflictsRequest,
+    pool: &PgPool,
+    user_id: &str,
+    req: CheckConflictsRequest,
 ) -> Result<Vec<ScheduleConflict>, AppError> {
-    todo!()
+    let min_gap = Duration::minutes(req.min_gap_minutes.unwrap_or(0) as i64);
+    let exclude_ids = req.exclude_ids.unwrap_or_default();
+
+    // 검색 범위를 min_gap만큼 확장
+    let search_start = req.start_at - min_gap;
+    let search_end = req.end_at.map(|e| e + min_gap);
+
+    // 유저의 accepted 그룹일정 조회
+    let group_schedules = match search_end {
+        Some(end) => {
+            sqlx::query_as::<_, Schedule>(
+                "SELECT s.* FROM schedules s \
+                 JOIN schedule_votes sv ON s.id = sv.schedule_id \
+                 WHERE sv.user_id = $1 \
+                   AND sv.status = 'accepted' \
+                   AND s.schedule_type = 'group' \
+                   AND s.start_at < $2 \
+                   AND (s.end_at > $3 OR s.end_at IS NULL) \
+                 ORDER BY s.start_at ASC",
+            )
+            .bind(user_id)
+            .bind(end)
+            .bind(search_start)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        }
+        None => {
+            sqlx::query_as::<_, Schedule>(
+                "SELECT s.* FROM schedules s \
+                 JOIN schedule_votes sv ON s.id = sv.schedule_id \
+                 WHERE sv.user_id = $1 \
+                   AND sv.status = 'accepted' \
+                   AND s.schedule_type = 'group' \
+                   AND (s.end_at > $2 OR s.end_at IS NULL) \
+                 ORDER BY s.start_at ASC",
+            )
+            .bind(user_id)
+            .bind(search_start)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        }
+    };
+
+    // 유저의 개인일정 조회
+    let personal_schedules = match search_end {
+        Some(end) => {
+            sqlx::query_as::<_, Schedule>(
+                "SELECT * FROM schedules \
+                 WHERE user_id = $1 \
+                   AND schedule_type = 'personal' \
+                   AND start_at < $2 \
+                   AND (end_at > $3 OR end_at IS NULL) \
+                 ORDER BY start_at ASC",
+            )
+            .bind(user_id)
+            .bind(end)
+            .bind(search_start)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        }
+        None => {
+            sqlx::query_as::<_, Schedule>(
+                "SELECT * FROM schedules \
+                 WHERE user_id = $1 \
+                   AND schedule_type = 'personal' \
+                   AND (end_at > $2 OR end_at IS NULL) \
+                 ORDER BY start_at ASC",
+            )
+            .bind(user_id)
+            .bind(search_start)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        }
+    };
+
+    let all_schedules: Vec<&Schedule> = group_schedules
+        .iter()
+        .chain(personal_schedules.iter())
+        .filter(|s| !exclude_ids.contains(&s.id))
+        .collect();
+
+    let proposed_start = req.start_at;
+    let proposed_end = req.end_at;
+
+    let mut conflicts: Vec<ScheduleConflict> = Vec::new();
+
+    for existing in &all_schedules {
+        let ex_start = existing.start_at;
+        let ex_end = existing.end_at;
+
+        // overlap 계산
+        let overlap_minutes = calculate_overlap_minutes(
+            proposed_start,
+            proposed_end,
+            ex_start,
+            ex_end,
+        );
+
+        // gap 계산 (겹치지 않는 경우)
+        let gap_minutes = if overlap_minutes > 0 {
+            0
+        } else {
+            calculate_gap_minutes(proposed_start, proposed_end, ex_start, ex_end)
+        };
+
+        let min_gap_minutes_val = req.min_gap_minutes.unwrap_or(0) as i64;
+
+        // 겹치거나, gap이 min_gap 미만이면 충돌
+        if overlap_minutes > 0 || gap_minutes < min_gap_minutes_val {
+            let conflict_type = match existing.schedule_type {
+                ScheduleType::Group => "group",
+                ScheduleType::Personal => "personal",
+            };
+
+            conflicts.push(ScheduleConflict {
+                id: existing.id.to_string(),
+                conflict_type: conflict_type.to_string(),
+                title: existing.title.clone(),
+                emoji: existing.emoji.clone(),
+                start_at: existing.start_at,
+                end_at: existing.end_at,
+                overlap_minutes,
+                gap_minutes,
+            });
+        }
+    }
+
+    // overlap 내림차순, gap 오름차순 정렬
+    conflicts.sort_by(|a, b| {
+        b.overlap_minutes
+            .cmp(&a.overlap_minutes)
+            .then(a.gap_minutes.cmp(&b.gap_minutes))
+    });
+
+    Ok(conflicts)
+}
+
+// ============================================================
+// 충돌 계산 헬퍼
+// ============================================================
+
+/// 두 시간 범위의 겹침 시간(분)을 계산
+fn calculate_overlap_minutes(
+    start_a: chrono::DateTime<Utc>,
+    end_a: Option<chrono::DateTime<Utc>>,
+    start_b: chrono::DateTime<Utc>,
+    end_b: Option<chrono::DateTime<Utc>>,
+) -> i64 {
+    // end가 None인 경우 start + 1시간으로 간주
+    let end_a = end_a.unwrap_or(start_a + Duration::hours(1));
+    let end_b = end_b.unwrap_or(start_b + Duration::hours(1));
+
+    let overlap_start = start_a.max(start_b);
+    let overlap_end = end_a.min(end_b);
+
+    if overlap_end > overlap_start {
+        (overlap_end - overlap_start).num_minutes()
+    } else {
+        0
+    }
+}
+
+/// 두 시간 범위 사이의 간격(분)을 계산 (겹치지 않는 경우)
+fn calculate_gap_minutes(
+    start_a: chrono::DateTime<Utc>,
+    end_a: Option<chrono::DateTime<Utc>>,
+    start_b: chrono::DateTime<Utc>,
+    end_b: Option<chrono::DateTime<Utc>>,
+) -> i64 {
+    let end_a = end_a.unwrap_or(start_a + Duration::hours(1));
+    let end_b = end_b.unwrap_or(start_b + Duration::hours(1));
+
+    if end_a <= start_b {
+        (start_b - end_a).num_minutes()
+    } else if end_b <= start_a {
+        (start_a - end_b).num_minutes()
+    } else {
+        0
+    }
+}
+
+// ============================================================
+// 반복일정 확장 헬퍼
+// ============================================================
+
+/// 반복일정을 지정된 날짜 범위 내의 인스턴스로 확장
+fn expand_recurring_in_range(
+    schedule: &RecurringSchedule,
+    range_start: NaiveDate,
+    range_end: NaiveDate,
+) -> Vec<RecurringInstance> {
+    let mut instances = Vec::new();
+
+    // 시리즈 시작일과 범위 시작일 중 더 늦은 날짜부터
+    let effective_start = schedule.series_start_date.max(range_start);
+    // 시리즈 종료일과 범위 종료일 중 더 이른 날짜까지
+    let effective_end = match schedule.series_end_date {
+        Some(series_end) => series_end.min(range_end),
+        None => range_end,
+    };
+
+    if effective_start > effective_end {
+        return instances;
+    }
+
+    let excluded_dates: Vec<NaiveDate> = schedule
+        .excluded_dates
+        .clone()
+        .unwrap_or_default();
+
+    // 오버라이드 파싱: { "YYYY-MM-DD": { "start_time": {...}, "end_time": {...}, "cancelled": bool } }
+    let overrides_map: serde_json::Map<String, serde_json::Value> = schedule
+        .overrides
+        .as_ref()
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+
+    let mut current = effective_start;
+    while current <= effective_end {
+        let should_include = match schedule.frequency {
+            RecurrenceFrequency::Daily => true,
+            RecurrenceFrequency::Weekly => {
+                if let Some(ref days) = schedule.days_of_week {
+                    // chrono: Monday=1, Sunday=7 (iso_weekday)
+                    let weekday = current.weekday().number_from_monday() as i16;
+                    days.contains(&weekday)
+                } else {
+                    false
+                }
+            }
+            RecurrenceFrequency::Monthly => {
+                if let Some(day_of_month) = schedule.day_of_month {
+                    current.day() as i16 == day_of_month
+                } else {
+                    false
+                }
+            }
+        };
+
+        if should_include && !excluded_dates.contains(&current) {
+            let date_str = current.format("%Y-%m-%d").to_string();
+            let override_entry = overrides_map.get(&date_str);
+
+            // 오버라이드에서 cancelled 확인
+            let is_cancelled = override_entry
+                .and_then(|v| v.get("cancelled"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            if !is_cancelled {
+                // 오버라이드된 시간 또는 기본 시간
+                let start_time = override_entry
+                    .and_then(|v| v.get("start_time"))
+                    .and_then(|v| {
+                        let hour = v.get("hour")?.as_i64()? as i16;
+                        let minute = v.get("minute")?.as_i64()? as i16;
+                        Some(TimeComponents { hour, minute })
+                    })
+                    .unwrap_or(TimeComponents {
+                        hour: schedule.start_time_hour,
+                        minute: schedule.start_time_minute,
+                    });
+
+                let end_time = override_entry
+                    .and_then(|v| v.get("end_time"))
+                    .and_then(|v| {
+                        let hour = v.get("hour")?.as_i64()? as i16;
+                        let minute = v.get("minute")?.as_i64()? as i16;
+                        Some(TimeComponents { hour, minute })
+                    })
+                    .or_else(|| {
+                        schedule.end_time_hour.map(|h| TimeComponents {
+                            hour: h,
+                            minute: schedule.end_time_minute.unwrap_or(0),
+                        })
+                    });
+
+                let location = schedule.location_name.as_ref().map(|name| LocationResponse {
+                    name: name.clone(),
+                    address: schedule.location_address.clone(),
+                    latitude: schedule.location_latitude,
+                    longitude: schedule.location_longitude,
+                });
+
+                instances.push(RecurringInstance {
+                    recurring_schedule_id: schedule.id,
+                    title: schedule.title.clone(),
+                    emoji: schedule.emoji.clone(),
+                    date: current,
+                    start_time,
+                    end_time,
+                    location,
+                });
+            }
+        }
+
+        // 다음 날로 이동 (overflow-safe)
+        match current.succ_opt() {
+            Some(next) => current = next,
+            None => break,
+        }
+    }
+
+    instances
 }
 
 // ============================================================
@@ -99,35 +1474,520 @@ pub async fn check_conflicts(
 // ============================================================
 
 pub async fn create_recurring_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _req: CreateRecurringScheduleRequest,
+    pool: &PgPool,
+    user_id: &str,
+    req: CreateRecurringScheduleRequest,
 ) -> Result<CreateRecurringScheduleResponse, AppError> {
-    todo!()
+    // 제목 검증: trim 후 빈 문자열이면 400
+    let title = req.title.trim().to_string();
+    if title.is_empty() {
+        return Err(AppError::BadRequest(
+            "제목은 비어있을 수 없습니다".to_string(),
+        ));
+    }
+
+    // frequency별 상호배타 필드 검증
+    match req.frequency {
+        RecurrenceFrequency::Daily => {
+            if req.days_of_week.is_some() {
+                return Err(AppError::BadRequest(
+                    "daily 빈도에서는 days_of_week를 설정할 수 없습니다".to_string(),
+                ));
+            }
+            if req.day_of_month.is_some() {
+                return Err(AppError::BadRequest(
+                    "daily 빈도에서는 day_of_month를 설정할 수 없습니다".to_string(),
+                ));
+            }
+        }
+        RecurrenceFrequency::Weekly => {
+            match &req.days_of_week {
+                None => {
+                    return Err(AppError::BadRequest(
+                        "weekly 빈도에서는 days_of_week가 필요합니다".to_string(),
+                    ));
+                }
+                Some(days) => {
+                    if days.is_empty() {
+                        return Err(AppError::BadRequest(
+                            "days_of_week는 비어있을 수 없습니다".to_string(),
+                        ));
+                    }
+                    // 서비스 레벨 검증: 1-7 범위
+                    if days.iter().any(|&d| !(1..=7).contains(&d)) {
+                        return Err(AppError::BadRequest(
+                            "days_of_week 값은 1-7 범위여야 합니다".to_string(),
+                        ));
+                    }
+                }
+            }
+            if req.day_of_month.is_some() {
+                return Err(AppError::BadRequest(
+                    "weekly 빈도에서는 day_of_month를 설정할 수 없습니다".to_string(),
+                ));
+            }
+        }
+        RecurrenceFrequency::Monthly => {
+            if req.days_of_week.is_some() {
+                return Err(AppError::BadRequest(
+                    "monthly 빈도에서는 days_of_week를 설정할 수 없습니다".to_string(),
+                ));
+            }
+            match req.day_of_month {
+                None => {
+                    return Err(AppError::BadRequest(
+                        "monthly 빈도에서는 day_of_month가 필요합니다".to_string(),
+                    ));
+                }
+                Some(day) => {
+                    if !(1..=31).contains(&day) {
+                        return Err(AppError::BadRequest(
+                            "day_of_month는 1-31 범위여야 합니다".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // start_time 검증
+    if !(0..=23).contains(&req.start_time.hour) || !(0..=59).contains(&req.start_time.minute) {
+        return Err(AppError::BadRequest(
+            "start_time이 유효하지 않습니다".to_string(),
+        ));
+    }
+
+    // end_time 검증 (있는 경우)
+    if let Some(ref end_time) = req.end_time {
+        if !(0..=23).contains(&end_time.hour) || !(0..=59).contains(&end_time.minute) {
+            return Err(AppError::BadRequest(
+                "end_time이 유효하지 않습니다".to_string(),
+            ));
+        }
+    }
+
+    // series_end_date >= series_start_date 검증
+    if let Some(end_date) = req.series_end_date {
+        if end_date < req.series_start_date {
+            return Err(AppError::BadRequest(
+                "series_end_date는 series_start_date 이후여야 합니다".to_string(),
+            ));
+        }
+    }
+
+    // location 분해
+    let (loc_name, loc_address, loc_lat, loc_lng) = match &req.location {
+        Some(loc) => (
+            Some(loc.name.clone()),
+            loc.address.clone(),
+            loc.latitude,
+            loc.longitude,
+        ),
+        None => (None, None, None, None),
+    };
+
+    // end_time 분해
+    let (end_hour, end_minute) = match &req.end_time {
+        Some(t) => (Some(t.hour), Some(t.minute)),
+        None => (None, None),
+    };
+
+    // days_of_week를 &[i16]로 변환
+    let days_of_week_vec = req.days_of_week.unwrap_or_default();
+    let days_of_week_slice: Option<&[i16]> = if days_of_week_vec.is_empty() {
+        None
+    } else {
+        Some(&days_of_week_vec)
+    };
+
+    let row = sqlx::query_as::<_, (Uuid, chrono::DateTime<chrono::Utc>)>(
+        "INSERT INTO recurring_schedules \
+         (user_id, title, emoji, description, \
+          start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
+          location_name, location_address, location_latitude, location_longitude, \
+          reminder_minutes_before, frequency, days_of_week, day_of_month, \
+          series_start_date, series_end_date) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, \
+                 $14::recurrence_frequency, $15, $16, $17, $18) \
+         RETURNING id, created_at",
+    )
+    .bind(user_id)
+    .bind(&title)
+    .bind(&req.emoji)
+    .bind(&req.description)
+    .bind(req.start_time.hour)
+    .bind(req.start_time.minute)
+    .bind(end_hour)
+    .bind(end_minute)
+    .bind(&loc_name)
+    .bind(&loc_address)
+    .bind(loc_lat)
+    .bind(loc_lng)
+    .bind(req.reminder_minutes_before)
+    .bind(&req.frequency)
+    .bind(days_of_week_slice)
+    .bind(req.day_of_month)
+    .bind(req.series_start_date)
+    .bind(req.series_end_date)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(CreateRecurringScheduleResponse {
+        id: row.0,
+        created_at: row.1,
+    })
 }
 
 pub async fn get_recurring_schedules(
-    _pool: &PgPool,
-    _user_id: &str,
+    pool: &PgPool,
+    user_id: &str,
 ) -> Result<Vec<RecurringSchedule>, AppError> {
-    todo!()
+    let rows = sqlx::query_as::<_, RecurringSchedule>(
+        "SELECT id, user_id, title, emoji, description, \
+         start_time_hour, start_time_minute, end_time_hour, end_time_minute, \
+         location_name, location_address, location_latitude, location_longitude, \
+         reminder_minutes_before, frequency AS \"frequency: RecurrenceFrequency\", \
+         days_of_week, day_of_month, \
+         series_start_date, series_end_date, excluded_dates, overrides, \
+         created_at, updated_at \
+         FROM recurring_schedules WHERE user_id = $1 \
+         ORDER BY created_at DESC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(rows)
 }
 
 pub async fn update_recurring_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _id: Uuid,
-    _req: UpdateRecurringScheduleRequest,
+    pool: &PgPool,
+    user_id: &str,
+    id: Uuid,
+    req: UpdateRecurringScheduleRequest,
 ) -> Result<(), AppError> {
-    todo!()
+    // 존재 확인
+    let existing = sqlx::query_as::<_, (String,)>(
+        "SELECT user_id FROM recurring_schedules WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
+
+    // 소유권 확인
+    if existing.0 != user_id {
+        return Err(AppError::Forbidden(
+            "본인의 반복일정만 수정할 수 있습니다".to_string(),
+        ));
+    }
+
+    // 필드 검증
+    if let Some(ref title) = req.title {
+        let trimmed = title.trim();
+        if trimmed.is_empty() {
+            return Err(AppError::BadRequest(
+                "제목은 비어있을 수 없습니다".to_string(),
+            ));
+        }
+    }
+
+    if let Some(ref start_time) = req.start_time {
+        if !(0..=23).contains(&start_time.hour) || !(0..=59).contains(&start_time.minute) {
+            return Err(AppError::BadRequest(
+                "start_time이 유효하지 않습니다".to_string(),
+            ));
+        }
+    }
+
+    if let Some(Some(ref end_time)) = req.end_time {
+        if !(0..=23).contains(&end_time.hour) || !(0..=59).contains(&end_time.minute) {
+            return Err(AppError::BadRequest(
+                "end_time이 유효하지 않습니다".to_string(),
+            ));
+        }
+    }
+
+    if let Some(ref frequency) = req.frequency {
+        match frequency {
+            RecurrenceFrequency::Daily => {
+                // days_of_week가 업데이트에 포함되어 있고 값이 있으면 에러
+                if let Some(Some(ref _days)) = req.days_of_week {
+                    return Err(AppError::BadRequest(
+                        "daily 빈도에서는 days_of_week를 설정할 수 없습니다".to_string(),
+                    ));
+                }
+                if let Some(Some(_)) = req.day_of_month {
+                    return Err(AppError::BadRequest(
+                        "daily 빈도에서는 day_of_month를 설정할 수 없습니다".to_string(),
+                    ));
+                }
+            }
+            RecurrenceFrequency::Weekly => {
+                if let Some(ref inner) = req.days_of_week {
+                    match inner {
+                        None => {
+                            return Err(AppError::BadRequest(
+                                "weekly 빈도에서는 days_of_week가 필요합니다".to_string(),
+                            ));
+                        }
+                        Some(days) => {
+                            if days.is_empty() {
+                                return Err(AppError::BadRequest(
+                                    "days_of_week는 비어있을 수 없습니다".to_string(),
+                                ));
+                            }
+                            if days.iter().any(|&d| !(1..=7).contains(&d)) {
+                                return Err(AppError::BadRequest(
+                                    "days_of_week 값은 1-7 범위여야 합니다".to_string(),
+                                ));
+                            }
+                        }
+                    }
+                }
+                if let Some(Some(_)) = req.day_of_month {
+                    return Err(AppError::BadRequest(
+                        "weekly 빈도에서는 day_of_month를 설정할 수 없습니다".to_string(),
+                    ));
+                }
+            }
+            RecurrenceFrequency::Monthly => {
+                if let Some(Some(ref _days)) = req.days_of_week {
+                    return Err(AppError::BadRequest(
+                        "monthly 빈도에서는 days_of_week를 설정할 수 없습니다".to_string(),
+                    ));
+                }
+                if let Some(ref inner) = req.day_of_month {
+                    match inner {
+                        None => {
+                            return Err(AppError::BadRequest(
+                                "monthly 빈도에서는 day_of_month가 필요합니다".to_string(),
+                            ));
+                        }
+                        Some(day) => {
+                            if !(1..=31).contains(day) {
+                                return Err(AppError::BadRequest(
+                                    "day_of_month는 1-31 범위여야 합니다".to_string(),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 동적 UPDATE 빌드
+    let mut set_clauses: Vec<String> = Vec::new();
+    let mut param_index = 1u32;
+
+    if req.title.is_some() {
+        set_clauses.push(format!("title = ${param_index}"));
+        param_index += 1;
+    }
+    if req.emoji.is_some() {
+        set_clauses.push(format!("emoji = ${param_index}"));
+        param_index += 1;
+    }
+    if req.description.is_some() {
+        set_clauses.push(format!("description = ${param_index}"));
+        param_index += 1;
+    }
+    if req.start_time.is_some() {
+        set_clauses.push(format!("start_time_hour = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("start_time_minute = ${param_index}"));
+        param_index += 1;
+    }
+    if req.end_time.is_some() {
+        set_clauses.push(format!("end_time_hour = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("end_time_minute = ${param_index}"));
+        param_index += 1;
+    }
+    if req.location.is_some() {
+        set_clauses.push(format!("location_name = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_address = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_latitude = ${param_index}"));
+        param_index += 1;
+        set_clauses.push(format!("location_longitude = ${param_index}"));
+        param_index += 1;
+    }
+    if req.reminder_minutes_before.is_some() {
+        set_clauses.push(format!("reminder_minutes_before = ${param_index}"));
+        param_index += 1;
+    }
+    if req.frequency.is_some() {
+        set_clauses.push(format!("frequency = ${param_index}::recurrence_frequency"));
+        param_index += 1;
+    }
+    if req.days_of_week.is_some() {
+        set_clauses.push(format!("days_of_week = ${param_index}"));
+        param_index += 1;
+    }
+    if req.day_of_month.is_some() {
+        set_clauses.push(format!("day_of_month = ${param_index}"));
+        param_index += 1;
+    }
+    if req.series_start_date.is_some() {
+        set_clauses.push(format!("series_start_date = ${param_index}"));
+        param_index += 1;
+    }
+    if req.series_end_date.is_some() {
+        set_clauses.push(format!("series_end_date = ${param_index}"));
+        param_index += 1;
+    }
+    if req.excluded_dates.is_some() {
+        set_clauses.push(format!("excluded_dates = ${param_index}"));
+        param_index += 1;
+    }
+    if req.overrides.is_some() {
+        set_clauses.push(format!("overrides = ${param_index}"));
+        param_index += 1;
+    }
+
+    if set_clauses.is_empty() {
+        return Ok(());
+    }
+
+    set_clauses.push("updated_at = NOW()".to_string());
+
+    let sql = format!(
+        "UPDATE recurring_schedules SET {} WHERE id = ${param_index}",
+        set_clauses.join(", "),
+    );
+
+    let mut query = sqlx::query(&sql);
+
+    // 바인딩 순서대로
+    if let Some(ref title) = req.title {
+        query = query.bind(title.trim().to_string());
+    }
+    if let Some(ref inner) = req.emoji {
+        match inner {
+            None => query = query.bind(None::<String>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(ref inner) = req.description {
+        match inner {
+            None => query = query.bind(None::<String>),
+            Some(v) => query = query.bind(Some(v.clone())),
+        }
+    }
+    if let Some(ref start_time) = req.start_time {
+        query = query.bind(start_time.hour);
+        query = query.bind(start_time.minute);
+    }
+    if let Some(ref inner) = req.end_time {
+        match inner {
+            None => {
+                query = query.bind(None::<i16>);
+                query = query.bind(None::<i16>);
+            }
+            Some(t) => {
+                query = query.bind(Some(t.hour));
+                query = query.bind(Some(t.minute));
+            }
+        }
+    }
+    if let Some(ref inner) = req.location {
+        match inner {
+            None => {
+                query = query.bind(None::<String>);
+                query = query.bind(None::<String>);
+                query = query.bind(None::<f64>);
+                query = query.bind(None::<f64>);
+            }
+            Some(loc) => {
+                query = query.bind(Some(loc.name.clone()));
+                query = query.bind(loc.address.clone());
+                query = query.bind(loc.latitude);
+                query = query.bind(loc.longitude);
+            }
+        }
+    }
+    if let Some(ref inner) = req.reminder_minutes_before {
+        match inner {
+            None => query = query.bind(None::<i16>),
+            Some(v) => query = query.bind(Some(*v)),
+        }
+    }
+    if let Some(ref frequency) = req.frequency {
+        query = query.bind(frequency);
+    }
+    if let Some(ref inner) = req.days_of_week {
+        match inner {
+            None => query = query.bind(None::<Vec<i16>>),
+            Some(days) => query = query.bind(Some(days.clone())),
+        }
+    }
+    if let Some(ref inner) = req.day_of_month {
+        match inner {
+            None => query = query.bind(None::<i16>),
+            Some(v) => query = query.bind(Some(*v)),
+        }
+    }
+    if let Some(ref date) = req.series_start_date {
+        query = query.bind(*date);
+    }
+    if let Some(ref inner) = req.series_end_date {
+        match inner {
+            None => query = query.bind(None::<chrono::NaiveDate>),
+            Some(d) => query = query.bind(Some(*d)),
+        }
+    }
+    if let Some(ref dates) = req.excluded_dates {
+        query = query.bind(dates.clone());
+    }
+    if let Some(ref overrides_val) = req.overrides {
+        query = query.bind(overrides_val.clone());
+    }
+
+    query = query.bind(id);
+
+    query
+        .execute(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(())
 }
 
 pub async fn delete_recurring_schedule(
-    _pool: &PgPool,
-    _user_id: &str,
-    _id: Uuid,
+    pool: &PgPool,
+    user_id: &str,
+    id: Uuid,
 ) -> Result<(), AppError> {
-    todo!()
+    // 존재 확인
+    let existing = sqlx::query_as::<_, (String,)>(
+        "SELECT user_id FROM recurring_schedules WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .ok_or_else(|| AppError::NotFound("반복일정을 찾을 수 없습니다".to_string()))?;
+
+    // 소유권 확인
+    if existing.0 != user_id {
+        return Err(AppError::Forbidden(
+            "본인의 반복일정만 삭제할 수 있습니다".to_string(),
+        ));
+    }
+
+    sqlx::query("DELETE FROM recurring_schedules WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(())
 }
 
 // ============================================================

--- a/infra/rust-backend/src/services/schedule_service.rs
+++ b/infra/rust-backend/src/services/schedule_service.rs
@@ -59,7 +59,7 @@ pub async fn get_group_schedules(
     _user_id: &str,
     _group_id: Uuid,
     _query: GroupScheduleQuery,
-) -> Result<Vec<ScheduleResponse>, AppError> {
+) -> Result<PaginatedScheduleResponse, AppError> {
     todo!()
 }
 
@@ -75,7 +75,7 @@ pub async fn get_calendar_schedules(
     _pool: &PgPool,
     _user_id: &str,
     _query: CalendarQuery,
-) -> Result<Vec<ScheduleResponse>, AppError> {
+) -> Result<CalendarResponse, AppError> {
     todo!()
 }
 
@@ -127,5 +127,17 @@ pub async fn delete_recurring_schedule(
     _user_id: &str,
     _id: Uuid,
 ) -> Result<(), AppError> {
+    todo!()
+}
+
+// ============================================================
+// AI 일정 추출
+// ============================================================
+
+pub async fn extract_schedule(
+    _pool: &PgPool,
+    _user_id: &str,
+    _req: ExtractScheduleRequest,
+) -> Result<ExtractScheduleResponse, AppError> {
     todo!()
 }

--- a/infra/rust-backend/src/services/user_service.rs
+++ b/infra/rust-backend/src/services/user_service.rs
@@ -134,22 +134,17 @@ pub async fn get_user_public(
 }
 
 /// 사용자 정보 수정 (닉네임) — U6: name/email은 UpdateUserRequest에 필드 자체가 없음
-pub async fn update_user(
-    pool: &PgPool,
-    uid: &str,
-    req: UpdateUserRequest,
-) -> Result<(), AppError> {
+pub async fn update_user(pool: &PgPool, uid: &str, req: UpdateUserRequest) -> Result<(), AppError> {
     if let Some(ref nickname) = req.nickname {
         let validated = validate_nickname(nickname)?;
 
-        let result = sqlx::query(
-            "UPDATE users SET nickname = $1, updated_at = NOW() WHERE id = $2",
-        )
-        .bind(&validated)
-        .bind(uid)
-        .execute(pool)
-        .await
-        .map_err(|e| map_unique_violation(e, "닉네임 변경 실패"))?;
+        let result =
+            sqlx::query("UPDATE users SET nickname = $1, updated_at = NOW() WHERE id = $2")
+                .bind(&validated)
+                .bind(uid)
+                .execute(pool)
+                .await
+                .map_err(|e| map_unique_violation(e, "닉네임 변경 실패"))?;
 
         if result.rows_affected() == 0 {
             return Err(AppError::NotFound("사용자를 찾을 수 없습니다".to_string()));
@@ -174,19 +169,20 @@ pub async fn upload_profile_image(
     // 보안: 사용자 소유 경로인지 검증 (임의 파일 참조 방지)
     let expected_prefix = format!("profile_images/{}/", uid);
     if !path.starts_with(&expected_prefix) {
-        return Err(AppError::BadRequest("이미지 경로가 올바르지 않습니다".to_string()));
+        return Err(AppError::BadRequest(
+            "이미지 경로가 올바르지 않습니다".to_string(),
+        ));
     }
 
     // 실제 Storage URL 생성은 Firebase Storage에서 처리 (ADR-007)
     let url = path;
 
-    let result =
-        sqlx::query("UPDATE users SET profile_url = $1, updated_at = NOW() WHERE id = $2")
-            .bind(&url)
-            .bind(uid)
-            .execute(pool)
-            .await
-            .map_err(|e| AppError::Internal(e.to_string()))?;
+    let result = sqlx::query("UPDATE users SET profile_url = $1, updated_at = NOW() WHERE id = $2")
+        .bind(&url)
+        .bind(uid)
+        .execute(pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
 
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound("사용자를 찾을 수 없습니다".to_string()));
@@ -204,16 +200,17 @@ pub async fn check_nickname_available(
     let trimmed = validate_nickname(nickname)?;
 
     // 같은 닉네임을 가진 사용자 검색 (본인 제외)
-    let existing = sqlx::query_scalar::<_, String>("SELECT id FROM users WHERE nickname = $1 LIMIT 1")
-        .bind(&trimmed)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let existing =
+        sqlx::query_scalar::<_, String>("SELECT id FROM users WHERE nickname = $1 LIMIT 1")
+            .bind(&trimmed)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
 
     let available = match existing {
-        None => true,                        // 아무도 안 씀
-        Some(ref id) if id == uid => true,   // 본인이 쓰고 있음
-        Some(_) => false,                    // 다른 사람이 쓰고 있음
+        None => true,                      // 아무도 안 씀
+        Some(ref id) if id == uid => true, // 본인이 쓰고 있음
+        Some(_) => false,                  // 다른 사람이 쓰고 있음
     };
 
     Ok(NicknameCheckResponse {

--- a/infra/rust-backend/tests/groups_test.rs
+++ b/infra/rust-backend/tests/groups_test.rs
@@ -470,8 +470,7 @@ async fn p8_join_already_member_rejected(pool: PgPool) {
     let group = create_test_group(&pool, "creator_p8", "중복가입").await;
 
     // 이미 멤버인 호스트가 재가입 시도
-    let result =
-        group_service::join_group(&pool, "creator_p8", &group.invite_code).await;
+    let result = group_service::join_group(&pool, "creator_p8", &group.invite_code).await;
     assert!(matches!(result, Err(AppError::Conflict(_))));
 }
 
@@ -493,8 +492,7 @@ async fn p9_join_full_group_rejected(pool: PgPool) {
 
     // 세 번째 유저가 가입 시도 → 정원 초과
     insert_test_user(&pool, "member_p9b", "멤버27b").await;
-    let result =
-        group_service::join_group(&pool, "member_p9b", &group.invite_code).await;
+    let result = group_service::join_group(&pool, "member_p9b", &group.invite_code).await;
     assert!(matches!(result, Err(AppError::BadRequest(_))));
 }
 
@@ -630,10 +628,9 @@ async fn s5_join_role_is_member(pool: PgPool) {
     insert_test_user(&pool, "joiner_s5", "가입자2").await;
 
     let group = create_test_group(&pool, "creator_s5", "역할검증").await;
-    let response =
-        group_service::join_group(&pool, "joiner_s5", &group.invite_code)
-            .await
-            .unwrap();
+    let response = group_service::join_group(&pool, "joiner_s5", &group.invite_code)
+        .await
+        .unwrap();
     assert_eq!(response.role, "member");
 }
 
@@ -643,10 +640,9 @@ async fn s6_join_default_notifications_on(pool: PgPool) {
     insert_test_user(&pool, "joiner_s6", "가입자3").await;
 
     let group = create_test_group(&pool, "creator_s6", "알림기본값").await;
-    let response =
-        group_service::join_group(&pool, "joiner_s6", &group.invite_code)
-            .await
-            .unwrap();
+    let response = group_service::join_group(&pool, "joiner_s6", &group.invite_code)
+        .await
+        .unwrap();
 
     let ns = &response.notification_settings;
     assert!(ns.enabled);
@@ -666,10 +662,9 @@ async fn s6_join_default_group_color_is_purple_hex(pool: PgPool) {
     insert_test_user(&pool, "joiner_s6c", "가입자3c").await;
 
     let group = create_test_group(&pool, "creator_s6c", "색상기본값").await;
-    let response =
-        group_service::join_group(&pool, "joiner_s6c", &group.invite_code)
-            .await
-            .unwrap();
+    let response = group_service::join_group(&pool, "joiner_s6c", &group.invite_code)
+        .await
+        .unwrap();
 
     assert_eq!(response.group_color, "#AF52DE");
 }
@@ -691,10 +686,9 @@ async fn s7_leave_success(pool: PgPool) {
     assert!(result.is_ok());
 
     // 탈퇴 후 멤버 목록에서 제거됨
-    let members =
-        group_service::fetch_group_members(&pool, "creator_s7", group_id)
-            .await
-            .unwrap();
+    let members = group_service::fetch_group_members(&pool, "creator_s7", group_id)
+        .await
+        .unwrap();
     assert!(!members.iter().any(|m| m.user_id == "member_s7"));
 }
 
@@ -817,10 +811,9 @@ async fn s11_transfer_old_host_becomes_member(pool: PgPool) {
         .await
         .unwrap();
 
-    let members =
-        group_service::fetch_group_members(&pool, "new_host_s11b", group_id)
-            .await
-            .unwrap();
+    let members = group_service::fetch_group_members(&pool, "new_host_s11b", group_id)
+        .await
+        .unwrap();
 
     let old_host = members.iter().find(|m| m.user_id == "creator_s11b");
     let new_host = members.iter().find(|m| m.user_id == "new_host_s11b");
@@ -850,10 +843,9 @@ async fn s12_expel_success(pool: PgPool) {
     assert!(result.is_ok());
 
     // 추방 후 멤버 목록에서 제거됨
-    let members =
-        group_service::fetch_group_members(&pool, "creator_s12", group_id)
-            .await
-            .unwrap();
+    let members = group_service::fetch_group_members(&pool, "creator_s12", group_id)
+        .await
+        .unwrap();
     assert!(!members.iter().any(|m| m.user_id == "target_s12"));
 }
 
@@ -1026,8 +1018,7 @@ async fn n2_update_notification_settings_non_member_forbidden(pool: PgPool) {
         calendar_sync: false,
     };
     let result =
-        group_service::update_notification_settings(&pool, "outsider_n2", group_id, settings)
-            .await;
+        group_service::update_notification_settings(&pool, "outsider_n2", group_id, settings).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
 
@@ -1126,8 +1117,7 @@ async fn b3_mark_group_read_by_non_member_rejected(pool: PgPool) {
     let group = create_test_group(&pool, "creator_b3", "읽음권한").await;
     let group_id = Uuid::parse_str(&group.group_id).unwrap();
 
-    let result =
-        group_service::mark_group_read(&pool, "outsider_b3", group_id).await;
+    let result = group_service::mark_group_read(&pool, "outsider_b3", group_id).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
 

--- a/infra/rust-backend/tests/schedules_test.rs
+++ b/infra/rust-backend/tests/schedules_test.rs
@@ -1,0 +1,1379 @@
+//! Schedules 도메인 비즈니스 규칙 테스트 (Red Phase)
+//!
+//! 모든 테스트는 컴파일은 되지만 실행 시 실패해야 한다.
+//! service 함수들이 todo!()를 반환하기 때문.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use promiso_backend::errors::AppError;
+use promiso_backend::models::schedule::*;
+use promiso_backend::services::schedule_service;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// ============================================================
+// 테스트 헬퍼
+// ============================================================
+
+async fn insert_test_user(pool: &PgPool, id: &str, nickname: &str) {
+    sqlx::query(
+        "INSERT INTO users (id, name, nickname, provider_type, provider_uid, email) \
+         VALUES ($1, $2, $3, 'google', 'test-uid', 'test@test.com')",
+    )
+    .bind(id)
+    .bind(nickname)
+    .bind(nickname)
+    .execute(pool)
+    .await
+    .expect("Failed to insert test user");
+}
+
+async fn create_test_group(pool: &PgPool, creator_id: &str, name: &str) -> Uuid {
+    let row: (Uuid,) = sqlx::query_as(
+        "INSERT INTO groups (name, host_uid, invite_code, max_members) \
+         VALUES ($1, $2, UPPER(SUBSTR(MD5(RANDOM()::TEXT), 1, 6)), 10) \
+         RETURNING id",
+    )
+    .bind(name)
+    .bind(creator_id)
+    .fetch_one(pool)
+    .await
+    .expect("Failed to create test group");
+
+    // 생성자를 admin으로 추가
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'admin')",
+    )
+    .bind(row.0)
+    .bind(creator_id)
+    .execute(pool)
+    .await
+    .expect("Failed to add creator as admin");
+
+    row.0
+}
+
+async fn add_member_to_group(pool: &PgPool, group_id: Uuid, user_id: &str) {
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'member')",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("Failed to add member to group");
+}
+
+fn make_group_schedule_request(
+    group_id: Uuid,
+    title: &str,
+    start_at: DateTime<Utc>,
+) -> CreateScheduleRequest {
+    CreateScheduleRequest {
+        schedule_type: ScheduleType::Group,
+        group_id: Some(group_id),
+        title: title.to_string(),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at,
+        end_at: None,
+        location: None,
+        minimum_participants: Some(2),
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    }
+}
+
+fn make_personal_schedule_request(
+    title: &str,
+    start_at: DateTime<Utc>,
+) -> CreateScheduleRequest {
+    CreateScheduleRequest {
+        schedule_type: ScheduleType::Personal,
+        group_id: None,
+        title: title.to_string(),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    }
+}
+
+fn make_recurring_request(
+    title: &str,
+    frequency: RecurrenceFrequency,
+) -> CreateRecurringScheduleRequest {
+    CreateRecurringScheduleRequest {
+        title: title.to_string(),
+        emoji: None,
+        description: None,
+        start_time: TimeComponents {
+            hour: 10,
+            minute: 0,
+        },
+        end_time: None,
+        location: None,
+        reminder_minutes_before: None,
+        frequency,
+        days_of_week: None,
+        day_of_month: None,
+        series_start_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+        series_end_date: None,
+    }
+}
+
+fn future_time(hours: i64) -> DateTime<Utc> {
+    Utc::now() + chrono::Duration::hours(hours)
+}
+
+fn past_time(hours: i64) -> DateTime<Utc> {
+    Utc::now() - chrono::Duration::hours(hours)
+}
+
+// ============================================================
+// 그룹일정 - 생성
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_success(pool: PgPool) {
+    insert_test_user(&pool, "user1", "유저1").await;
+    let group_id = create_test_group(&pool, "user1", "테스트그룹").await;
+
+    let req = make_group_schedule_request(group_id, "팀 회의", future_time(24));
+    let result = schedule_service::create_schedule(&pool, "user1", req).await;
+
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.title, "팀 회의");
+    assert_eq!(response.group_id, Some(group_id));
+    // min_participants=2, 호스트만 수락 → 미확정
+    assert_eq!(response.is_confirmed, Some(false));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_host_auto_accepted(pool: PgPool) {
+    // P16: 생성 후 schedule_votes에 호스트가 accepted 상태로 존재해야 함
+    insert_test_user(&pool, "host_p16", "호스트P16").await;
+    let group_id = create_test_group(&pool, "host_p16", "자동수락그룹").await;
+
+    let req = make_group_schedule_request(group_id, "자동수락일정", future_time(24));
+    let response = schedule_service::create_schedule(&pool, "host_p16", req)
+        .await
+        .expect("create should succeed");
+
+    // DB에서 직접 투표 확인
+    let vote: Option<(String,)> = sqlx::query_as(
+        "SELECT status::text FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2",
+    )
+    .bind(response.schedule_id)
+    .bind("host_p16")
+    .fetch_optional(&pool)
+    .await
+    .expect("query failed");
+
+    assert!(vote.is_some());
+    assert_eq!(vote.unwrap().0, "accepted");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_confirmed_when_min_is_1(pool: PgPool) {
+    // min_participants=1 → 호스트 자동수락으로 즉시 확정
+    insert_test_user(&pool, "host_min1", "호스트Min1").await;
+    let group_id = create_test_group(&pool, "host_min1", "즉시확정그룹").await;
+
+    let mut req = make_group_schedule_request(group_id, "즉시확정", future_time(24));
+    req.minimum_participants = Some(1);
+
+    let result = schedule_service::create_schedule(&pool, "host_min1", req).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().is_confirmed, Some(true));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_vote_deadline_equals_start_at(pool: PgPool) {
+    // P19: vote_deadline == start_at
+    insert_test_user(&pool, "host_p19", "호스트P19").await;
+    let group_id = create_test_group(&pool, "host_p19", "데드라인그룹").await;
+
+    let start = future_time(48);
+    let req = make_group_schedule_request(group_id, "데드라인테스트", start);
+    let response = schedule_service::create_schedule(&pool, "host_p19", req)
+        .await
+        .expect("create should succeed");
+
+    // DB에서 직접 vote_deadline 확인
+    let row: (DateTime<Utc>, DateTime<Utc>) = sqlx::query_as(
+        "SELECT start_at, vote_deadline FROM schedules WHERE id = $1",
+    )
+    .bind(response.schedule_id)
+    .fetch_one(&pool)
+    .await
+    .expect("query failed");
+
+    assert_eq!(row.0, row.1);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_non_member_fails(pool: PgPool) {
+    // P9: 비멤버가 그룹일정 생성 시도 → Forbidden
+    insert_test_user(&pool, "host_p9", "호스트P9").await;
+    insert_test_user(&pool, "outsider_p9", "외부인P9").await;
+    let group_id = create_test_group(&pool, "host_p9", "비멤버테스트").await;
+
+    let req = make_group_schedule_request(group_id, "불법생성", future_time(24));
+    let result = schedule_service::create_schedule(&pool, "outsider_p9", req).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_group_not_found(pool: PgPool) {
+    // 존재하지 않는 group_id → NotFound
+    insert_test_user(&pool, "host_gnf", "호스트GNF").await;
+
+    let fake_group_id = Uuid::new_v4();
+    let req = make_group_schedule_request(fake_group_id, "유령그룹일정", future_time(24));
+    let result = schedule_service::create_schedule(&pool, "host_gnf", req).await;
+    assert!(matches!(result, Err(AppError::NotFound(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_title_empty_fails(pool: PgPool) {
+    // 공백만 있는 제목 → BadRequest
+    insert_test_user(&pool, "host_te", "호스트TE").await;
+    let group_id = create_test_group(&pool, "host_te", "빈제목그룹").await;
+
+    let req = make_group_schedule_request(group_id, "   ", future_time(24));
+    let result = schedule_service::create_schedule(&pool, "host_te", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_title_too_long_fails(pool: PgPool) {
+    // 31자 제목 → BadRequest
+    insert_test_user(&pool, "host_tl", "호스트TL").await;
+    let group_id = create_test_group(&pool, "host_tl", "긴제목그룹").await;
+
+    let long_title = "가".repeat(31); // 31자
+    let req = make_group_schedule_request(group_id, &long_title, future_time(24));
+    let result = schedule_service::create_schedule(&pool, "host_tl", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_description_too_long_fails(pool: PgPool) {
+    // 501자 설명 → BadRequest
+    insert_test_user(&pool, "host_dl", "호스트DL").await;
+    let group_id = create_test_group(&pool, "host_dl", "긴설명그룹").await;
+
+    let mut req = make_group_schedule_request(group_id, "설명테스트", future_time(24));
+    req.description = Some("가".repeat(501));
+
+    let result = schedule_service::create_schedule(&pool, "host_dl", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_min_participants_zero_fails(pool: PgPool) {
+    // minimum_participants = 0 → BadRequest
+    insert_test_user(&pool, "host_mp0", "호스트MP0").await;
+    let group_id = create_test_group(&pool, "host_mp0", "최소0그룹").await;
+
+    let mut req = make_group_schedule_request(group_id, "최소0일정", future_time(24));
+    req.minimum_participants = Some(0);
+
+    let result = schedule_service::create_schedule(&pool, "host_mp0", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_end_before_start_fails(pool: PgPool) {
+    // end_at < start_at → BadRequest
+    insert_test_user(&pool, "host_ebs", "호스트EBS").await;
+    let group_id = create_test_group(&pool, "host_ebs", "역순시간그룹").await;
+
+    let start = future_time(48);
+    let end = future_time(24); // start보다 이전
+    let mut req = make_group_schedule_request(group_id, "역순일정", start);
+    req.end_at = Some(end);
+
+    let result = schedule_service::create_schedule(&pool, "host_ebs", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_end_equals_start_fails(pool: PgPool) {
+    // end_at == start_at → BadRequest (strictly after)
+    insert_test_user(&pool, "host_ees", "호스트EES").await;
+    let group_id = create_test_group(&pool, "host_ees", "동일시간그룹").await;
+
+    let time = future_time(24);
+    let mut req = make_group_schedule_request(group_id, "동일시간일정", time);
+    req.end_at = Some(time);
+
+    let result = schedule_service::create_schedule(&pool, "host_ees", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_description_blocks_max_20(pool: PgPool) {
+    // 21개 description_blocks → BadRequest
+    insert_test_user(&pool, "host_db21", "호스트DB21").await;
+    let group_id = create_test_group(&pool, "host_db21", "블록초과그룹").await;
+
+    let blocks: Vec<serde_json::Value> = (0..21)
+        .map(|i| serde_json::json!({"type": "text", "content": format!("block {}", i)}))
+        .collect();
+    let mut req = make_group_schedule_request(group_id, "블록초과일정", future_time(24));
+    req.description_blocks = Some(serde_json::Value::Array(blocks));
+
+    let result = schedule_service::create_schedule(&pool, "host_db21", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_image_urls_max_3(pool: PgPool) {
+    // 4개 이미지 URL → BadRequest
+    insert_test_user(&pool, "host_img4", "호스트IMG4").await;
+    let group_id = create_test_group(&pool, "host_img4", "이미지초과그룹").await;
+
+    let mut req = make_group_schedule_request(group_id, "이미지초과", future_time(24));
+    req.image_urls = Some(vec![
+        "https://example.com/1.jpg".to_string(),
+        "https://example.com/2.jpg".to_string(),
+        "https://example.com/3.jpg".to_string(),
+        "https://example.com/4.jpg".to_string(),
+    ]);
+
+    let result = schedule_service::create_schedule(&pool, "host_img4", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+// ============================================================
+// 그룹일정 - 응답 (투표)
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_accept_success(pool: PgPool) {
+    insert_test_user(&pool, "host_ra", "호스트RA").await;
+    insert_test_user(&pool, "member_ra", "멤버RA").await;
+    let group_id = create_test_group(&pool, "host_ra", "수락그룹").await;
+    add_member_to_group(&pool, group_id, "member_ra").await;
+
+    let req = make_group_schedule_request(group_id, "수락테스트", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_ra", req)
+        .await
+        .expect("create should succeed");
+
+    let respond_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_ra", schedule.schedule_id, respond_req)
+            .await;
+    assert!(result.is_ok());
+
+    let response = result.unwrap();
+    assert_eq!(response.status, "accepted");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_decline_success(pool: PgPool) {
+    insert_test_user(&pool, "host_rd", "호스트RD").await;
+    insert_test_user(&pool, "member_rd", "멤버RD").await;
+    let group_id = create_test_group(&pool, "host_rd", "거절그룹").await;
+    add_member_to_group(&pool, group_id, "member_rd").await;
+
+    let req = make_group_schedule_request(group_id, "거절테스트", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_rd", req)
+        .await
+        .expect("create should succeed");
+
+    let respond_req = RespondScheduleRequest {
+        status: "declined".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_rd", schedule.schedule_id, respond_req)
+            .await;
+    assert!(result.is_ok());
+
+    let response = result.unwrap();
+    assert_eq!(response.status, "declined");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_pending_removes_vote(pool: PgPool) {
+    // P28: pending으로 응답하면 schedule_votes에서 삭제
+    insert_test_user(&pool, "host_rp", "호스트RP").await;
+    insert_test_user(&pool, "member_rp", "멤버RP").await;
+    let group_id = create_test_group(&pool, "host_rp", "보류그룹").await;
+    add_member_to_group(&pool, group_id, "member_rp").await;
+
+    let req = make_group_schedule_request(group_id, "보류테스트", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_rp", req)
+        .await
+        .expect("create should succeed");
+
+    // 먼저 수락
+    let accept_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    schedule_service::respond_schedule(&pool, "member_rp", schedule.schedule_id, accept_req)
+        .await
+        .expect("accept should succeed");
+
+    // pending으로 변경
+    let pending_req = RespondScheduleRequest {
+        status: "pending".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_rp", schedule.schedule_id, pending_req)
+            .await;
+    assert!(result.is_ok());
+
+    // DB에서 투표 삭제 확인
+    let vote_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM schedule_votes WHERE schedule_id = $1 AND user_id = $2",
+    )
+    .bind(schedule.schedule_id)
+    .bind("member_rp")
+    .fetch_one(&pool)
+    .await
+    .expect("query failed");
+
+    assert_eq!(vote_count.0, 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_same_status_noop(pool: PgPool) {
+    // P27: 이미 accepted인데 다시 accepted → 에러 없이 동일 상태 유지
+    insert_test_user(&pool, "host_rn", "호스트RN").await;
+    insert_test_user(&pool, "member_rn", "멤버RN").await;
+    let group_id = create_test_group(&pool, "host_rn", "중복응답그룹").await;
+    add_member_to_group(&pool, group_id, "member_rn").await;
+
+    let req = make_group_schedule_request(group_id, "중복응답", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_rn", req)
+        .await
+        .expect("create should succeed");
+
+    let accept_req1 = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    schedule_service::respond_schedule(&pool, "member_rn", schedule.schedule_id, accept_req1)
+        .await
+        .expect("first accept should succeed");
+
+    let accept_req2 = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_rn", schedule.schedule_id, accept_req2)
+            .await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_recalculates_confirmed(pool: PgPool) {
+    // P29: min_participants=2, 호스트 수락(1). 멤버 수락 → is_confirmed = true
+    insert_test_user(&pool, "host_rc", "호스트RC").await;
+    insert_test_user(&pool, "member_rc", "멤버RC").await;
+    let group_id = create_test_group(&pool, "host_rc", "확정재계산").await;
+    add_member_to_group(&pool, group_id, "member_rc").await;
+
+    let req = make_group_schedule_request(group_id, "확정재계산일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_rc", req)
+        .await
+        .expect("create should succeed");
+
+    // 아직 미확정 (호스트만 수락, min=2)
+    assert_eq!(schedule.is_confirmed, Some(false));
+
+    let accept_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_rc", schedule.schedule_id, accept_req)
+            .await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_confirmed);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_unconfirms_on_decline(pool: PgPool) {
+    // min_participants=2, 호스트+멤버 수락 (확정). 멤버 거절 → 미확정
+    insert_test_user(&pool, "host_ru", "호스트RU").await;
+    insert_test_user(&pool, "member_ru", "멤버RU").await;
+    let group_id = create_test_group(&pool, "host_ru", "확정취소").await;
+    add_member_to_group(&pool, group_id, "member_ru").await;
+
+    let req = make_group_schedule_request(group_id, "확정취소일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_ru", req)
+        .await
+        .expect("create should succeed");
+
+    // 멤버 수락 → 확정
+    let accept_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let confirmed =
+        schedule_service::respond_schedule(&pool, "member_ru", schedule.schedule_id, accept_req)
+            .await
+            .expect("accept should succeed");
+    assert!(confirmed.is_confirmed);
+
+    // 멤버 거절 → 미확정
+    let decline_req = RespondScheduleRequest {
+        status: "declined".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_ru", schedule.schedule_id, decline_req)
+            .await;
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_confirmed);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_non_member_fails(pool: PgPool) {
+    // P15: 그룹 비멤버 → Forbidden
+    insert_test_user(&pool, "host_rnm", "호스트RNM").await;
+    insert_test_user(&pool, "outsider_rnm", "외부인RNM").await;
+    let group_id = create_test_group(&pool, "host_rnm", "비멤버응답").await;
+
+    let req = make_group_schedule_request(group_id, "비멤버응답일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_rnm", req)
+        .await
+        .expect("create should succeed");
+
+    let respond_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result = schedule_service::respond_schedule(
+        &pool,
+        "outsider_rnm",
+        schedule.schedule_id,
+        respond_req,
+    )
+    .await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_not_found(pool: PgPool) {
+    // 존재하지 않는 schedule_id → NotFound
+    insert_test_user(&pool, "user_rnf", "유저RNF").await;
+
+    let respond_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "user_rnf", Uuid::new_v4(), respond_req).await;
+    assert!(matches!(result, Err(AppError::NotFound(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_returns_confirmed_schedule(pool: PgPool) {
+    // is_confirmed && status=="accepted" → confirmed_schedule에 정보 포함
+    insert_test_user(&pool, "host_rcs", "호스트RCS").await;
+    insert_test_user(&pool, "member_rcs", "멤버RCS").await;
+    let group_id = create_test_group(&pool, "host_rcs", "확정응답").await;
+    add_member_to_group(&pool, group_id, "member_rcs").await;
+
+    let mut req = make_group_schedule_request(group_id, "확정일정응답", future_time(24));
+    req.minimum_participants = Some(2);
+
+    let schedule = schedule_service::create_schedule(&pool, "host_rcs", req)
+        .await
+        .expect("create should succeed");
+
+    let accept_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_rcs", schedule.schedule_id, accept_req)
+            .await;
+    assert!(result.is_ok());
+
+    let response = result.unwrap();
+    assert!(response.is_confirmed);
+    assert!(response.confirmed_schedule.is_some());
+
+    let confirmed = response.confirmed_schedule.unwrap();
+    assert_eq!(confirmed.id, schedule.schedule_id);
+    assert_eq!(confirmed.title, "확정일정응답");
+    assert_eq!(confirmed.group_id, group_id);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn respond_schedule_invalid_status_fails(pool: PgPool) {
+    // status = "invalid" → BadRequest
+    insert_test_user(&pool, "host_ris", "호스트RIS").await;
+    insert_test_user(&pool, "member_ris", "멤버RIS").await;
+    let group_id = create_test_group(&pool, "host_ris", "잘못된상태").await;
+    add_member_to_group(&pool, group_id, "member_ris").await;
+
+    let req = make_group_schedule_request(group_id, "잘못된상태일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_ris", req)
+        .await
+        .expect("create should succeed");
+
+    let respond_req = RespondScheduleRequest {
+        status: "invalid".to_string(),
+    };
+    let result =
+        schedule_service::respond_schedule(&pool, "member_ris", schedule.schedule_id, respond_req)
+            .await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+// ============================================================
+// 그룹일정 - 수정
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_host_success(pool: PgPool) {
+    // 일정 호스트가 제목 수정 → 성공
+    insert_test_user(&pool, "host_us", "호스트US").await;
+    let group_id = create_test_group(&pool, "host_us", "수정그룹").await;
+
+    let req = make_group_schedule_request(group_id, "원래제목", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_us", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("새제목".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "host_us", schedule.schedule_id, update_req)
+            .await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_group_host_success(pool: PgPool) {
+    // P10: 그룹 관리자(일정 호스트가 아님)도 수정 가능
+    insert_test_user(&pool, "admin_ugh", "관리자UGH").await;
+    insert_test_user(&pool, "member_ugh", "멤버UGH").await;
+    let group_id = create_test_group(&pool, "admin_ugh", "관리자수정").await;
+    add_member_to_group(&pool, group_id, "member_ugh").await;
+
+    // 멤버가 일정 생성 (일정 호스트 = member_ugh)
+    let req = make_group_schedule_request(group_id, "멤버일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "member_ugh", req)
+        .await
+        .expect("create should succeed");
+
+    // 그룹 관리자가 수정
+    let update_req = UpdateScheduleRequest {
+        title: Some("관리자수정됨".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "admin_ugh", schedule.schedule_id, update_req)
+            .await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_non_host_fails(pool: PgPool) {
+    // 일반 멤버(일정 호스트도 아니고 그룹 관리자도 아님) → Forbidden
+    insert_test_user(&pool, "host_unf", "호스트UNF").await;
+    insert_test_user(&pool, "member_unf", "멤버UNF").await;
+    let group_id = create_test_group(&pool, "host_unf", "수정거부").await;
+    add_member_to_group(&pool, group_id, "member_unf").await;
+
+    let req = make_group_schedule_request(group_id, "호스트일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_unf", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("불법수정".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "member_unf", schedule.schedule_id, update_req)
+            .await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_started_fails(pool: PgPool) {
+    // P12: 이미 시작된 일정 수정 시도 → PreconditionFailed
+    insert_test_user(&pool, "host_usf", "호스트USF").await;
+    let group_id = create_test_group(&pool, "host_usf", "시작됨수정").await;
+
+    // 과거 시간의 일정을 직접 DB에 삽입
+    let schedule_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO schedules (id, schedule_type, user_id, title, start_at, group_id, \
+         minimum_participants, is_confirmed, vote_deadline) \
+         VALUES ($1, 'group', $2, '과거일정', $3, $4, 2, false, $3)",
+    )
+    .bind(schedule_id)
+    .bind("host_usf")
+    .bind(past_time(1))
+    .bind(group_id)
+    .execute(&pool)
+    .await
+    .expect("insert past schedule failed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("수정시도".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "host_usf", schedule_id, update_req).await;
+    assert!(matches!(result, Err(AppError::PreconditionFailed(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_start_at_syncs_vote_deadline(pool: PgPool) {
+    // P30: start_at 변경 시 vote_deadline도 새 start_at으로 동기화
+    insert_test_user(&pool, "host_usd", "호스트USD").await;
+    let group_id = create_test_group(&pool, "host_usd", "데드라인동기화").await;
+
+    let req = make_group_schedule_request(group_id, "동기화테스트", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_usd", req)
+        .await
+        .expect("create should succeed");
+
+    let new_start = future_time(72);
+    let update_req = UpdateScheduleRequest {
+        title: None,
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: Some(new_start),
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    schedule_service::update_schedule(&pool, "host_usd", schedule.schedule_id, update_req)
+        .await
+        .expect("update should succeed");
+
+    // DB에서 vote_deadline 확인
+    let row: (DateTime<Utc>, DateTime<Utc>) = sqlx::query_as(
+        "SELECT start_at, vote_deadline FROM schedules WHERE id = $1",
+    )
+    .bind(schedule.schedule_id)
+    .fetch_one(&pool)
+    .await
+    .expect("query failed");
+
+    assert_eq!(row.0, row.1);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_title_empty_fails(pool: PgPool) {
+    // 빈 제목 → BadRequest
+    insert_test_user(&pool, "host_ute", "호스트UTE").await;
+    let group_id = create_test_group(&pool, "host_ute", "빈제목수정").await;
+
+    let req = make_group_schedule_request(group_id, "원래제목", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_ute", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "host_ute", schedule.schedule_id, update_req)
+            .await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_title_too_long_fails(pool: PgPool) {
+    // 31자 초과 제목 → BadRequest
+    insert_test_user(&pool, "host_utl", "호스트UTL").await;
+    let group_id = create_test_group(&pool, "host_utl", "긴제목수정").await;
+
+    let req = make_group_schedule_request(group_id, "원래제목", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_utl", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("가".repeat(31)),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "host_utl", schedule.schedule_id, update_req)
+            .await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+// ============================================================
+// 그룹일정 - 삭제
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_schedule_host_success(pool: PgPool) {
+    // 일정 호스트가 삭제 → 성공
+    insert_test_user(&pool, "host_ds", "호스트DS").await;
+    let group_id = create_test_group(&pool, "host_ds", "삭제그룹").await;
+
+    let req = make_group_schedule_request(group_id, "삭제대상", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_ds", req)
+        .await
+        .expect("create should succeed");
+
+    let result =
+        schedule_service::delete_schedule(&pool, "host_ds", schedule.schedule_id).await;
+    assert!(result.is_ok());
+
+    // DB에서 삭제 확인
+    let count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM schedules WHERE id = $1")
+            .bind(schedule.schedule_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query failed");
+    assert_eq!(count.0, 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_schedule_group_host_success(pool: PgPool) {
+    // P11: 그룹 관리자도 삭제 가능
+    insert_test_user(&pool, "admin_dg", "관리자DG").await;
+    insert_test_user(&pool, "member_dg", "멤버DG").await;
+    let group_id = create_test_group(&pool, "admin_dg", "관리자삭제").await;
+    add_member_to_group(&pool, group_id, "member_dg").await;
+
+    // 멤버가 일정 생성
+    let req = make_group_schedule_request(group_id, "멤버삭제대상", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "member_dg", req)
+        .await
+        .expect("create should succeed");
+
+    // 그룹 관리자가 삭제
+    let result =
+        schedule_service::delete_schedule(&pool, "admin_dg", schedule.schedule_id).await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_schedule_non_host_fails(pool: PgPool) {
+    // 일반 멤버 → Forbidden
+    insert_test_user(&pool, "host_dnf", "호스트DNF").await;
+    insert_test_user(&pool, "member_dnf", "멤버DNF").await;
+    let group_id = create_test_group(&pool, "host_dnf", "삭제거부").await;
+    add_member_to_group(&pool, group_id, "member_dnf").await;
+
+    let req = make_group_schedule_request(group_id, "삭제거부일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_dnf", req)
+        .await
+        .expect("create should succeed");
+
+    let result =
+        schedule_service::delete_schedule(&pool, "member_dnf", schedule.schedule_id).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_schedule_started_fails(pool: PgPool) {
+    // P13: 이미 시작된 일정 삭제 시도 → PreconditionFailed
+    insert_test_user(&pool, "host_dsf", "호스트DSF").await;
+    let group_id = create_test_group(&pool, "host_dsf", "시작됨삭제").await;
+
+    let schedule_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO schedules (id, schedule_type, user_id, title, start_at, group_id, \
+         minimum_participants, is_confirmed, vote_deadline) \
+         VALUES ($1, 'group', $2, '과거삭제', $3, $4, 2, false, $3)",
+    )
+    .bind(schedule_id)
+    .bind("host_dsf")
+    .bind(past_time(1))
+    .bind(group_id)
+    .execute(&pool)
+    .await
+    .expect("insert past schedule failed");
+
+    let result = schedule_service::delete_schedule(&pool, "host_dsf", schedule_id).await;
+    assert!(matches!(result, Err(AppError::PreconditionFailed(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_schedule_cascades_votes(pool: PgPool) {
+    // 삭제 후 schedule_votes도 함께 삭제
+    insert_test_user(&pool, "host_dcv", "호스트DCV").await;
+    insert_test_user(&pool, "member_dcv", "멤버DCV").await;
+    let group_id = create_test_group(&pool, "host_dcv", "캐스케이드").await;
+    add_member_to_group(&pool, group_id, "member_dcv").await;
+
+    let req = make_group_schedule_request(group_id, "캐스케이드일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_dcv", req)
+        .await
+        .expect("create should succeed");
+
+    // 멤버 수락
+    let accept_req = RespondScheduleRequest {
+        status: "accepted".to_string(),
+    };
+    schedule_service::respond_schedule(&pool, "member_dcv", schedule.schedule_id, accept_req)
+        .await
+        .expect("accept should succeed");
+
+    // 삭제
+    schedule_service::delete_schedule(&pool, "host_dcv", schedule.schedule_id)
+        .await
+        .expect("delete should succeed");
+
+    // 투표도 삭제되었는지 확인
+    let vote_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM schedule_votes WHERE schedule_id = $1")
+            .bind(schedule.schedule_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query failed");
+    assert_eq!(vote_count.0, 0);
+}
+
+// ============================================================
+// 개인일정
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_personal_schedule_success(pool: PgPool) {
+    insert_test_user(&pool, "user_ps", "유저PS").await;
+
+    let req = make_personal_schedule_request("개인일정", future_time(24));
+    let result = schedule_service::create_schedule(&pool, "user_ps", req).await;
+
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.title, "개인일정");
+    assert!(response.group_id.is_none());
+    assert!(response.is_confirmed.is_none());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_personal_schedule_owner_only(pool: PgPool) {
+    // 소유자만 조회 가능, 다른 유저 → Forbidden
+    insert_test_user(&pool, "owner_gpo", "소유자GPO").await;
+    insert_test_user(&pool, "other_gpo", "타인GPO").await;
+
+    let req = make_personal_schedule_request("비공개일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "owner_gpo", req)
+        .await
+        .expect("create should succeed");
+
+    // 소유자 조회 → 성공
+    let owner_result =
+        schedule_service::get_schedule(&pool, "owner_gpo", schedule.schedule_id).await;
+    assert!(owner_result.is_ok());
+
+    // 타인 조회 → Forbidden
+    let other_result =
+        schedule_service::get_schedule(&pool, "other_gpo", schedule.schedule_id).await;
+    assert!(matches!(other_result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_personal_schedule_owner_only(pool: PgPool) {
+    // 소유자만 수정 가능
+    insert_test_user(&pool, "owner_upo", "소유자UPO").await;
+    insert_test_user(&pool, "other_upo", "타인UPO").await;
+
+    let req = make_personal_schedule_request("수정대상개인일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "owner_upo", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: Some("수정됨".to_string()),
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "other_upo", schedule.schedule_id, update_req)
+            .await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_personal_schedule_owner_only(pool: PgPool) {
+    // 소유자만 삭제 가능
+    insert_test_user(&pool, "owner_dpo", "소유자DPO").await;
+    insert_test_user(&pool, "other_dpo", "타인DPO").await;
+
+    let req = make_personal_schedule_request("삭제대상개인일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "owner_dpo", req)
+        .await
+        .expect("create should succeed");
+
+    let result =
+        schedule_service::delete_schedule(&pool, "other_dpo", schedule.schedule_id).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_personal_schedule_with_group_id_fails(pool: PgPool) {
+    // schedule_type=personal + group_id 설정 → BadRequest
+    insert_test_user(&pool, "user_pgf", "유저PGF").await;
+    let group_id = create_test_group(&pool, "user_pgf", "개인+그룹").await;
+
+    let mut req = make_personal_schedule_request("잘못된개인일정", future_time(24));
+    req.group_id = Some(group_id);
+
+    let result = schedule_service::create_schedule(&pool, "user_pgf", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+// ============================================================
+// 반복일정
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_daily_success(pool: PgPool) {
+    insert_test_user(&pool, "user_crd", "유저CRD").await;
+
+    let req = make_recurring_request("매일운동", RecurrenceFrequency::Daily);
+    let result = schedule_service::create_recurring_schedule(&pool, "user_crd", req).await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_weekly_success(pool: PgPool) {
+    insert_test_user(&pool, "user_crw", "유저CRW").await;
+
+    let mut req = make_recurring_request("주간미팅", RecurrenceFrequency::Weekly);
+    req.days_of_week = Some(vec![2, 4, 6]); // 화, 목, 토
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_crw", req).await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_monthly_success(pool: PgPool) {
+    insert_test_user(&pool, "user_crm", "유저CRM").await;
+
+    let mut req = make_recurring_request("월간보고", RecurrenceFrequency::Monthly);
+    req.day_of_month = Some(15);
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_crm", req).await;
+    assert!(result.is_ok());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_weekly_missing_days_fails(pool: PgPool) {
+    // frequency=weekly, days_of_week=None → BadRequest
+    insert_test_user(&pool, "user_rwmd", "유저RWMD").await;
+
+    let req = make_recurring_request("요일없는주간", RecurrenceFrequency::Weekly);
+    // days_of_week = None (기본값)
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_rwmd", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_monthly_missing_day_fails(pool: PgPool) {
+    // frequency=monthly, day_of_month=None → BadRequest
+    insert_test_user(&pool, "user_rmmd", "유저RMMD").await;
+
+    let req = make_recurring_request("일자없는월간", RecurrenceFrequency::Monthly);
+    // day_of_month = None (기본값)
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_rmmd", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_daily_with_extra_fields_fails(pool: PgPool) {
+    // frequency=daily + days_of_week 설정 → BadRequest (상호배타)
+    insert_test_user(&pool, "user_rdef", "유저RDEF").await;
+
+    let mut req = make_recurring_request("잘못된매일", RecurrenceFrequency::Daily);
+    req.days_of_week = Some(vec![1, 2]);
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_rdef", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_monthly_out_of_range_fails(pool: PgPool) {
+    // day_of_month=32 → BadRequest
+    insert_test_user(&pool, "user_rmor", "유저RMOR").await;
+
+    let mut req = make_recurring_request("범위초과월간", RecurrenceFrequency::Monthly);
+    req.day_of_month = Some(32);
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user_rmor", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn delete_recurring_schedule_owner_only(pool: PgPool) {
+    // 소유자만 삭제 가능
+    insert_test_user(&pool, "owner_drs", "소유자DRS").await;
+    insert_test_user(&pool, "other_drs", "타인DRS").await;
+
+    let req = make_recurring_request("삭제대상반복", RecurrenceFrequency::Daily);
+    let recurring = schedule_service::create_recurring_schedule(&pool, "owner_drs", req)
+        .await
+        .expect("create should succeed");
+
+    let result =
+        schedule_service::delete_recurring_schedule(&pool, "other_drs", recurring.id).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_recurring_schedules_returns_own_only(pool: PgPool) {
+    // 각 유저는 자신의 반복일정만 조회
+    insert_test_user(&pool, "user1_grs", "유저1GRS").await;
+    insert_test_user(&pool, "user2_grs", "유저2GRS").await;
+
+    let req1 = make_recurring_request("유저1반복", RecurrenceFrequency::Daily);
+    schedule_service::create_recurring_schedule(&pool, "user1_grs", req1)
+        .await
+        .expect("create should succeed");
+
+    let req2 = make_recurring_request("유저2반복", RecurrenceFrequency::Daily);
+    schedule_service::create_recurring_schedule(&pool, "user2_grs", req2)
+        .await
+        .expect("create should succeed");
+
+    let user1_list = schedule_service::get_recurring_schedules(&pool, "user1_grs")
+        .await
+        .expect("get should succeed");
+    assert_eq!(user1_list.len(), 1);
+    assert_eq!(user1_list[0].title, "유저1반복");
+
+    let user2_list = schedule_service::get_recurring_schedules(&pool, "user2_grs")
+        .await
+        .expect("get should succeed");
+    assert_eq!(user2_list.len(), 1);
+    assert_eq!(user2_list[0].title, "유저2반복");
+}
+
+// ============================================================
+// 목록/조회
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_group_schedules_active(pool: PgPool) {
+    // 미래 일정 2개 + 과거 일정 1개 → active 조회 시 2개만 반환
+    insert_test_user(&pool, "host_gsa", "호스트GSA").await;
+    let group_id = create_test_group(&pool, "host_gsa", "활성조회").await;
+
+    // 미래 일정 2개
+    let req1 = make_group_schedule_request(group_id, "미래일정1", future_time(24));
+    schedule_service::create_schedule(&pool, "host_gsa", req1)
+        .await
+        .expect("create1 should succeed");
+
+    let req2 = make_group_schedule_request(group_id, "미래일정2", future_time(48));
+    schedule_service::create_schedule(&pool, "host_gsa", req2)
+        .await
+        .expect("create2 should succeed");
+
+    // 과거 일정 직접 삽입
+    sqlx::query(
+        "INSERT INTO schedules (schedule_type, user_id, title, start_at, group_id, \
+         minimum_participants, is_confirmed, vote_deadline) \
+         VALUES ('group', $1, '과거일정', $2, $3, 2, false, $2)",
+    )
+    .bind("host_gsa")
+    .bind(past_time(24))
+    .bind(group_id)
+    .execute(&pool)
+    .await
+    .expect("insert past schedule failed");
+
+    let query = GroupScheduleQuery {
+        status: Some("active".to_string()),
+        limit: None,
+        cursor: None,
+    };
+    let result =
+        schedule_service::get_group_schedules(&pool, "host_gsa", group_id, query).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 2);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_group_schedules_past_with_pagination(pool: PgPool) {
+    // 과거 일정 5개, limit=2 → 2개 반환
+    insert_test_user(&pool, "host_gsp", "호스트GSP").await;
+    let group_id = create_test_group(&pool, "host_gsp", "과거페이징").await;
+
+    for i in 1..=5 {
+        sqlx::query(
+            "INSERT INTO schedules (schedule_type, user_id, title, start_at, group_id, \
+             minimum_participants, is_confirmed, vote_deadline) \
+             VALUES ('group', $1, $2, $3, $4, 2, false, $3)",
+        )
+        .bind("host_gsp")
+        .bind(format!("과거일정{}", i))
+        .bind(past_time(i * 24))
+        .bind(group_id)
+        .execute(&pool)
+        .await
+        .expect("insert past schedule failed");
+    }
+
+    let query = GroupScheduleQuery {
+        status: Some("past".to_string()),
+        limit: Some(2),
+        cursor: None,
+    };
+    let result =
+        schedule_service::get_group_schedules(&pool, "host_gsp", group_id, query).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 2);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_group_schedules_non_member_fails(pool: PgPool) {
+    // 비멤버 → Forbidden
+    insert_test_user(&pool, "host_gsnm", "호스트GSNM").await;
+    insert_test_user(&pool, "outsider_gsnm", "외부인GSNM").await;
+    let group_id = create_test_group(&pool, "host_gsnm", "비멤버조회").await;
+
+    let query = GroupScheduleQuery {
+        status: Some("active".to_string()),
+        limit: None,
+        cursor: None,
+    };
+    let result =
+        schedule_service::get_group_schedules(&pool, "outsider_gsnm", group_id, query).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_home_schedules_multi_group(pool: PgPool) {
+    // 유저가 2개 그룹에 속해 있고, 각 그룹에 미래 일정 → 합산 결과, start_at 정렬
+    insert_test_user(&pool, "user_ghm", "유저GHM").await;
+    let group1 = create_test_group(&pool, "user_ghm", "그룹A").await;
+    let group2 = create_test_group(&pool, "user_ghm", "그룹B").await;
+
+    let req1 = make_group_schedule_request(group1, "그룹A일정", future_time(48));
+    schedule_service::create_schedule(&pool, "user_ghm", req1)
+        .await
+        .expect("create1 should succeed");
+
+    let req2 = make_group_schedule_request(group2, "그룹B일정", future_time(24));
+    schedule_service::create_schedule(&pool, "user_ghm", req2)
+        .await
+        .expect("create2 should succeed");
+
+    let query = HomeQuery { limit: None };
+    let result = schedule_service::get_home_schedules(&pool, "user_ghm", query).await;
+    assert!(result.is_ok());
+
+    let schedules = result.unwrap();
+    assert!(schedules.len() >= 2);
+    // start_at 오름차순 정렬 확인
+    if schedules.len() >= 2 {
+        assert!(schedules[0].start_at <= schedules[1].start_at);
+    }
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_calendar_sync_confirmed_only(pool: PgPool) {
+    // 확정 1개 + 미확정 1개 → 확정된 것만 반환
+    insert_test_user(&pool, "user_gcs", "유저GCS").await;
+    insert_test_user(&pool, "member_gcs", "멤버GCS").await;
+    let group_id = create_test_group(&pool, "user_gcs", "캘린더동기화").await;
+    add_member_to_group(&pool, group_id, "member_gcs").await;
+
+    // 확정 일정: min=1 → 호스트 수락으로 즉시 확정
+    let mut req1 = make_group_schedule_request(group_id, "확정일정", future_time(24));
+    req1.minimum_participants = Some(1);
+    schedule_service::create_schedule(&pool, "user_gcs", req1)
+        .await
+        .expect("create confirmed should succeed");
+
+    // 미확정 일정: min=2, 호스트만 수락
+    let req2 = make_group_schedule_request(group_id, "미확정일정", future_time(48));
+    schedule_service::create_schedule(&pool, "user_gcs", req2)
+        .await
+        .expect("create unconfirmed should succeed");
+
+    let result = schedule_service::get_calendar_sync(&pool, "user_gcs").await;
+    assert!(result.is_ok());
+
+    let synced = result.unwrap();
+    assert_eq!(synced.len(), 1);
+    assert_eq!(synced[0].title, "확정일정");
+}

--- a/infra/rust-backend/tests/schedules_test.rs
+++ b/infra/rust-backend/tests/schedules_test.rs
@@ -29,17 +29,16 @@ async fn insert_test_user(pool: &PgPool, id: &str, nickname: &str) {
 
 async fn create_test_group(pool: &PgPool, creator_id: &str, name: &str) -> Uuid {
     let row: (Uuid,) = sqlx::query_as(
-        "INSERT INTO groups (name, host_uid, invite_code, max_members) \
-         VALUES ($1, $2, UPPER(SUBSTR(MD5(RANDOM()::TEXT), 1, 6)), 10) \
+        "INSERT INTO groups (name, invite_code, max_members, description, image_url, last_activity_at) \
+         VALUES ($1, UPPER(SUBSTR(MD5(RANDOM()::TEXT), 1, 6)), 10, NULL, NULL, NOW()) \
          RETURNING id",
     )
     .bind(name)
-    .bind(creator_id)
     .fetch_one(pool)
     .await
     .expect("Failed to create test group");
 
-    // 생성자를 admin으로 추가
+    // 생성자를 admin으로 추가 (groups 테이블에 host_uid 없음, group_members로 관리)
     sqlx::query(
         "INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'admin')",
     )
@@ -184,9 +183,11 @@ async fn create_group_schedule_host_auto_accepted(pool: PgPool) {
 
 #[sqlx::test(migrations = "./migrations")]
 async fn create_group_schedule_confirmed_when_min_is_1(pool: PgPool) {
-    // min_participants=1 → 호스트 자동수락으로 즉시 확정
+    // P6 예외: 1인 그룹에서만 minimum_participants=1 허용
+    // 그룹에 호스트만 존재 (멤버 추가 없음) → min=1, 호스트 자동수락으로 즉시 확정
     insert_test_user(&pool, "host_min1", "호스트Min1").await;
     let group_id = create_test_group(&pool, "host_min1", "즉시확정그룹").await;
+    // 다른 멤버를 추가하지 않음 — 1인 그룹
 
     let mut req = make_group_schedule_request(group_id, "즉시확정", future_time(24));
     req.minimum_participants = Some(1);
@@ -1182,6 +1183,18 @@ async fn create_recurring_monthly_out_of_range_fails(pool: PgPool) {
 }
 
 #[sqlx::test(migrations = "./migrations")]
+async fn create_recurring_weekly_invalid_day_range_fails(pool: PgPool) {
+    // days_of_week 값은 1-7 범위여야 함 (0, 8은 범위 밖)
+    insert_test_user(&pool, "user1", "nick1").await;
+
+    let mut req = make_recurring_request("invalid weekday", RecurrenceFrequency::Weekly);
+    req.days_of_week = Some(vec![0, 8]); // 0 and 8 are out of 1-7 range
+
+    let result = schedule_service::create_recurring_schedule(&pool, "user1", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
 async fn delete_recurring_schedule_owner_only(pool: PgPool) {
     // 소유자만 삭제 가능
     insert_test_user(&pool, "owner_drs", "소유자DRS").await;
@@ -1268,7 +1281,8 @@ async fn get_group_schedules_active(pool: PgPool) {
     let result =
         schedule_service::get_group_schedules(&pool, "host_gsa", group_id, query).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap().len(), 2);
+    let response = result.unwrap();
+    assert_eq!(response.data.len(), 2);
 }
 
 #[sqlx::test(migrations = "./migrations")]
@@ -1300,7 +1314,10 @@ async fn get_group_schedules_past_with_pagination(pool: PgPool) {
     let result =
         schedule_service::get_group_schedules(&pool, "host_gsp", group_id, query).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap().len(), 2);
+    let response = result.unwrap();
+    assert_eq!(response.data.len(), 2);
+    // cursor가 있으면 다음 페이지 존재
+    assert!(response.cursor.is_some());
 }
 
 #[sqlx::test(migrations = "./migrations")]

--- a/infra/rust-backend/tests/schedules_test.rs
+++ b/infra/rust-backend/tests/schedules_test.rs
@@ -1,9 +1,6 @@
-//! Schedules 도메인 비즈니스 규칙 테스트 (Red Phase)
-//!
-//! 모든 테스트는 컴파일은 되지만 실행 시 실패해야 한다.
-//! service 함수들이 todo!()를 반환하기 때문.
+//! Schedules 도메인 비즈니스 규칙 테스트
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use promiso_backend::errors::AppError;
 use promiso_backend::models::schedule::*;
 use promiso_backend::services::schedule_service;
@@ -39,27 +36,23 @@ async fn create_test_group(pool: &PgPool, creator_id: &str, name: &str) -> Uuid 
     .expect("Failed to create test group");
 
     // 생성자를 admin으로 추가 (groups 테이블에 host_uid 없음, group_members로 관리)
-    sqlx::query(
-        "INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'admin')",
-    )
-    .bind(row.0)
-    .bind(creator_id)
-    .execute(pool)
-    .await
-    .expect("Failed to add creator as admin");
+    sqlx::query("INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'admin')")
+        .bind(row.0)
+        .bind(creator_id)
+        .execute(pool)
+        .await
+        .expect("Failed to add creator as admin");
 
     row.0
 }
 
 async fn add_member_to_group(pool: &PgPool, group_id: Uuid, user_id: &str) {
-    sqlx::query(
-        "INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'member')",
-    )
-    .bind(group_id)
-    .bind(user_id)
-    .execute(pool)
-    .await
-    .expect("Failed to add member to group");
+    sqlx::query("INSERT INTO group_members (group_id, user_id, role) VALUES ($1, $2, 'member')")
+        .bind(group_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("Failed to add member to group");
 }
 
 fn make_group_schedule_request(
@@ -84,10 +77,7 @@ fn make_group_schedule_request(
     }
 }
 
-fn make_personal_schedule_request(
-    title: &str,
-    start_at: DateTime<Utc>,
-) -> CreateScheduleRequest {
+fn make_personal_schedule_request(title: &str, start_at: DateTime<Utc>) -> CreateScheduleRequest {
     CreateScheduleRequest {
         schedule_type: ScheduleType::Personal,
         group_id: None,
@@ -210,13 +200,12 @@ async fn create_group_schedule_vote_deadline_equals_start_at(pool: PgPool) {
         .expect("create should succeed");
 
     // DB에서 직접 vote_deadline 확인
-    let row: (DateTime<Utc>, DateTime<Utc>) = sqlx::query_as(
-        "SELECT start_at, vote_deadline FROM schedules WHERE id = $1",
-    )
-    .bind(response.schedule_id)
-    .fetch_one(&pool)
-    .await
-    .expect("query failed");
+    let row: (DateTime<Utc>, DateTime<Utc>) =
+        sqlx::query_as("SELECT start_at, vote_deadline FROM schedules WHERE id = $1")
+            .bind(response.schedule_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query failed");
 
     assert_eq!(row.0, row.1);
 }
@@ -290,6 +279,32 @@ async fn create_group_schedule_min_participants_zero_fails(pool: PgPool) {
     req.minimum_participants = Some(0);
 
     let result = schedule_service::create_schedule(&pool, "host_mp0", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_past_start_fails(pool: PgPool) {
+    // P4: 시작 시간은 현재보다 미래여야 함
+    insert_test_user(&pool, "host_past", "호스트과거").await;
+    let group_id = create_test_group(&pool, "host_past", "과거시작그룹").await;
+
+    let req = make_group_schedule_request(group_id, "과거시작일정", past_time(1));
+    let result = schedule_service::create_schedule(&pool, "host_past", req).await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn create_group_schedule_min_one_requires_single_member_group(pool: PgPool) {
+    // P6: minimum_participants=1은 1인 그룹에서만 허용
+    insert_test_user(&pool, "host_min_rule", "호스트MinRule").await;
+    insert_test_user(&pool, "member_min_rule", "멤버MinRule").await;
+    let group_id = create_test_group(&pool, "host_min_rule", "최소인원예외그룹").await;
+    add_member_to_group(&pool, group_id, "member_min_rule").await;
+
+    let mut req = make_group_schedule_request(group_id, "잘못된즉시확정", future_time(24));
+    req.minimum_participants = Some(1);
+
+    let result = schedule_service::create_schedule(&pool, "host_min_rule", req).await;
     assert!(matches!(result, Err(AppError::BadRequest(_))));
 }
 
@@ -662,8 +677,7 @@ async fn update_schedule_host_success(pool: PgPool) {
         reminder_minutes_before: None,
     };
     let result =
-        schedule_service::update_schedule(&pool, "host_us", schedule.schedule_id, update_req)
-            .await;
+        schedule_service::update_schedule(&pool, "host_us", schedule.schedule_id, update_req).await;
     assert!(result.is_ok());
 }
 
@@ -802,13 +816,12 @@ async fn update_schedule_start_at_syncs_vote_deadline(pool: PgPool) {
         .expect("update should succeed");
 
     // DB에서 vote_deadline 확인
-    let row: (DateTime<Utc>, DateTime<Utc>) = sqlx::query_as(
-        "SELECT start_at, vote_deadline FROM schedules WHERE id = $1",
-    )
-    .bind(schedule.schedule_id)
-    .fetch_one(&pool)
-    .await
-    .expect("query failed");
+    let row: (DateTime<Utc>, DateTime<Utc>) =
+        sqlx::query_as("SELECT start_at, vote_deadline FROM schedules WHERE id = $1")
+            .bind(schedule.schedule_id)
+            .fetch_one(&pool)
+            .await
+            .expect("query failed");
 
     assert_eq!(row.0, row.1);
 }
@@ -873,6 +886,87 @@ async fn update_schedule_title_too_long_fails(pool: PgPool) {
     assert!(matches!(result, Err(AppError::BadRequest(_))));
 }
 
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_start_at_past_fails(pool: PgPool) {
+    // P4/P12: 미래 일정도 과거로 옮길 수는 없음
+    insert_test_user(&pool, "host_usp", "호스트USP").await;
+    let group_id = create_test_group(&pool, "host_usp", "과거이동금지").await;
+
+    let req = make_group_schedule_request(group_id, "미래일정", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_usp", req)
+        .await
+        .expect("create should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: None,
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: Some(past_time(1)),
+        end_at: None,
+        location: None,
+        minimum_participants: None,
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    let result =
+        schedule_service::update_schedule(&pool, "host_usp", schedule.schedule_id, update_req)
+            .await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn update_schedule_minimum_participants_recalculates_confirmed(pool: PgPool) {
+    // minimum_participants 변경 시 is_confirmed도 즉시 재계산되어야 함
+    insert_test_user(&pool, "host_umr", "호스트UMR").await;
+    insert_test_user(&pool, "member1_umr", "멤버1UMR").await;
+    insert_test_user(&pool, "member2_umr", "멤버2UMR").await;
+    let group_id = create_test_group(&pool, "host_umr", "확정재계산수정").await;
+    add_member_to_group(&pool, group_id, "member1_umr").await;
+    add_member_to_group(&pool, group_id, "member2_umr").await;
+
+    let req = make_group_schedule_request(group_id, "확정상태변경", future_time(24));
+    let schedule = schedule_service::create_schedule(&pool, "host_umr", req)
+        .await
+        .expect("create should succeed");
+
+    schedule_service::respond_schedule(
+        &pool,
+        "member1_umr",
+        schedule.schedule_id,
+        RespondScheduleRequest {
+            status: "accepted".to_string(),
+        },
+    )
+    .await
+    .expect("accept should succeed");
+
+    let update_req = UpdateScheduleRequest {
+        title: None,
+        emoji: None,
+        description: None,
+        description_blocks: None,
+        start_at: None,
+        end_at: None,
+        location: None,
+        minimum_participants: Some(3),
+        tracking_start_minutes_before: None,
+        image_urls: None,
+        reminder_minutes_before: None,
+    };
+    schedule_service::update_schedule(&pool, "host_umr", schedule.schedule_id, update_req)
+        .await
+        .expect("update should succeed");
+
+    let row: (bool,) = sqlx::query_as("SELECT is_confirmed FROM schedules WHERE id = $1")
+        .bind(schedule.schedule_id)
+        .fetch_one(&pool)
+        .await
+        .expect("query failed");
+    assert!(!row.0);
+}
+
 // ============================================================
 // 그룹일정 - 삭제
 // ============================================================
@@ -888,17 +982,15 @@ async fn delete_schedule_host_success(pool: PgPool) {
         .await
         .expect("create should succeed");
 
-    let result =
-        schedule_service::delete_schedule(&pool, "host_ds", schedule.schedule_id).await;
+    let result = schedule_service::delete_schedule(&pool, "host_ds", schedule.schedule_id).await;
     assert!(result.is_ok());
 
     // DB에서 삭제 확인
-    let count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM schedules WHERE id = $1")
-            .bind(schedule.schedule_id)
-            .fetch_one(&pool)
-            .await
-            .expect("query failed");
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM schedules WHERE id = $1")
+        .bind(schedule.schedule_id)
+        .fetch_one(&pool)
+        .await
+        .expect("query failed");
     assert_eq!(count.0, 0);
 }
 
@@ -917,8 +1009,7 @@ async fn delete_schedule_group_host_success(pool: PgPool) {
         .expect("create should succeed");
 
     // 그룹 관리자가 삭제
-    let result =
-        schedule_service::delete_schedule(&pool, "admin_dg", schedule.schedule_id).await;
+    let result = schedule_service::delete_schedule(&pool, "admin_dg", schedule.schedule_id).await;
     assert!(result.is_ok());
 }
 
@@ -935,8 +1026,7 @@ async fn delete_schedule_non_host_fails(pool: PgPool) {
         .await
         .expect("create should succeed");
 
-    let result =
-        schedule_service::delete_schedule(&pool, "member_dnf", schedule.schedule_id).await;
+    let result = schedule_service::delete_schedule(&pool, "member_dnf", schedule.schedule_id).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
 
@@ -1081,8 +1171,7 @@ async fn delete_personal_schedule_owner_only(pool: PgPool) {
         .await
         .expect("create should succeed");
 
-    let result =
-        schedule_service::delete_schedule(&pool, "other_dpo", schedule.schedule_id).await;
+    let result = schedule_service::delete_schedule(&pool, "other_dpo", schedule.schedule_id).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
 
@@ -1278,8 +1367,7 @@ async fn get_group_schedules_active(pool: PgPool) {
         limit: None,
         cursor: None,
     };
-    let result =
-        schedule_service::get_group_schedules(&pool, "host_gsa", group_id, query).await;
+    let result = schedule_service::get_group_schedules(&pool, "host_gsa", group_id, query).await;
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response.data.len(), 2);
@@ -1311,8 +1399,7 @@ async fn get_group_schedules_past_with_pagination(pool: PgPool) {
         limit: Some(2),
         cursor: None,
     };
-    let result =
-        schedule_service::get_group_schedules(&pool, "host_gsp", group_id, query).await;
+    let result = schedule_service::get_group_schedules(&pool, "host_gsp", group_id, query).await;
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response.data.len(), 2);
@@ -1374,12 +1461,21 @@ async fn get_calendar_sync_confirmed_only(pool: PgPool) {
     let group_id = create_test_group(&pool, "user_gcs", "캘린더동기화").await;
     add_member_to_group(&pool, group_id, "member_gcs").await;
 
-    // 확정 일정: min=1 → 호스트 수락으로 즉시 확정
-    let mut req1 = make_group_schedule_request(group_id, "확정일정", future_time(24));
-    req1.minimum_participants = Some(1);
-    schedule_service::create_schedule(&pool, "user_gcs", req1)
+    // 확정 일정: min=2, 멤버까지 수락
+    let req1 = make_group_schedule_request(group_id, "확정일정", future_time(24));
+    let confirmed_schedule = schedule_service::create_schedule(&pool, "user_gcs", req1)
         .await
         .expect("create confirmed should succeed");
+    schedule_service::respond_schedule(
+        &pool,
+        "member_gcs",
+        confirmed_schedule.schedule_id,
+        RespondScheduleRequest {
+            status: "accepted".to_string(),
+        },
+    )
+    .await
+    .expect("member accept should succeed");
 
     // 미확정 일정: min=2, 호스트만 수락
     let req2 = make_group_schedule_request(group_id, "미확정일정", future_time(48));
@@ -1393,4 +1489,165 @@ async fn get_calendar_sync_confirmed_only(pool: PgPool) {
     let synced = result.unwrap();
     assert_eq!(synced.len(), 1);
     assert_eq!(synced[0].title, "확정일정");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_calendar_schedules_zero_duration_without_end_at_only_on_start_day(pool: PgPool) {
+    insert_test_user(&pool, "user_gcz", "유저GCZ").await;
+
+    let start_at = Utc.with_ymd_and_hms(2026, 12, 1, 10, 0, 0).unwrap();
+    let req = make_personal_schedule_request("단발일정", start_at);
+    schedule_service::create_schedule(&pool, "user_gcz", req)
+        .await
+        .expect("create should succeed");
+
+    let same_day = schedule_service::get_calendar_schedules(
+        &pool,
+        "user_gcz",
+        CalendarQuery {
+            start: Utc.with_ymd_and_hms(2026, 12, 1, 0, 0, 0).unwrap(),
+            end: Utc.with_ymd_and_hms(2026, 12, 2, 0, 0, 0).unwrap(),
+            accepted_only: None,
+            timezone: Some("UTC".to_string()),
+        },
+    )
+    .await
+    .expect("same day query should succeed");
+    assert_eq!(same_day.schedules.len(), 1);
+
+    let next_day = schedule_service::get_calendar_schedules(
+        &pool,
+        "user_gcz",
+        CalendarQuery {
+            start: Utc.with_ymd_and_hms(2026, 12, 2, 0, 0, 0).unwrap(),
+            end: Utc.with_ymd_and_hms(2026, 12, 3, 0, 0, 0).unwrap(),
+            accepted_only: None,
+            timezone: Some("UTC".to_string()),
+        },
+    )
+    .await
+    .expect("next day query should succeed");
+    assert_eq!(next_day.schedules.len(), 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_calendar_schedules_recurring_respects_timezone_and_camelcase_overrides(pool: PgPool) {
+    insert_test_user(&pool, "user_gcr", "유저GCR").await;
+
+    sqlx::query(
+        "INSERT INTO recurring_schedules \
+         (user_id, title, start_time_hour, start_time_minute, frequency, days_of_week, \
+          series_start_date, overrides, location_name) \
+         VALUES ($1, $2, 9, 0, 'weekly', $3, $4, $5, $6)",
+    )
+    .bind("user_gcr")
+    .bind("기본제목")
+    .bind(vec![1_i16])
+    .bind(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap())
+    .bind(serde_json::json!({
+        "2026-04-05": {
+            "title": "오버라이드제목",
+            "startTime": { "hour": 17, "minute": 30 },
+            "location": { "name": "오버라이드장소" },
+            "isCancelled": false
+        }
+    }))
+    .bind("기본장소")
+    .execute(&pool)
+    .await
+    .expect("insert recurring schedule failed");
+
+    let response = schedule_service::get_calendar_schedules(
+        &pool,
+        "user_gcr",
+        CalendarQuery {
+            start: Utc.with_ymd_and_hms(2026, 4, 4, 16, 0, 0).unwrap(),
+            end: Utc.with_ymd_and_hms(2026, 4, 4, 18, 0, 0).unwrap(),
+            accepted_only: None,
+            timezone: Some("Asia/Seoul".to_string()),
+        },
+    )
+    .await
+    .expect("calendar query should succeed");
+
+    assert_eq!(response.recurring_instances.len(), 1);
+    let instance = &response.recurring_instances[0];
+    assert_eq!(instance.date, NaiveDate::from_ymd_opt(2026, 4, 5).unwrap());
+    assert_eq!(instance.title, "오버라이드제목");
+    assert_eq!(instance.start_time.hour, 17);
+    assert_eq!(instance.start_time.minute, 30);
+    assert_eq!(
+        instance
+            .location
+            .as_ref()
+            .map(|location| location.name.as_str()),
+        Some("오버라이드장소")
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn check_conflicts_includes_recurring_instances(pool: PgPool) {
+    insert_test_user(&pool, "user_ccr", "유저CCR").await;
+
+    sqlx::query(
+        "INSERT INTO recurring_schedules \
+         (user_id, title, start_time_hour, start_time_minute, frequency, series_start_date) \
+         VALUES ($1, $2, 10, 0, 'daily', $3)",
+    )
+    .bind("user_ccr")
+    .bind("매일운동")
+    .bind(NaiveDate::from_ymd_opt(2026, 12, 1).unwrap())
+    .execute(&pool)
+    .await
+    .expect("insert recurring schedule failed");
+
+    let conflicts = schedule_service::check_conflicts(
+        &pool,
+        "user_ccr",
+        CheckConflictsRequest {
+            start_at: Utc.with_ymd_and_hms(2026, 12, 2, 10, 0, 0).unwrap(),
+            end_at: Some(Utc.with_ymd_and_hms(2026, 12, 2, 11, 0, 0).unwrap()),
+            min_gap_minutes: Some(0),
+            exclude_ids: None,
+            timezone: Some("UTC".to_string()),
+        },
+    )
+    .await
+    .expect("conflict check should succeed");
+
+    assert!(conflicts
+        .iter()
+        .any(|conflict| conflict.conflict_type == "recurring"));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn check_conflicts_zero_duration_same_time_conflicts(pool: PgPool) {
+    insert_test_user(&pool, "user_ccz", "유저CCZ").await;
+
+    let start_at = Utc.with_ymd_and_hms(2026, 12, 3, 10, 0, 0).unwrap();
+    let created = schedule_service::create_schedule(
+        &pool,
+        "user_ccz",
+        make_personal_schedule_request("점일정", start_at),
+    )
+    .await
+    .expect("create should succeed");
+
+    let conflicts = schedule_service::check_conflicts(
+        &pool,
+        "user_ccz",
+        CheckConflictsRequest {
+            start_at,
+            end_at: None,
+            min_gap_minutes: Some(0),
+            exclude_ids: None,
+            timezone: Some("UTC".to_string()),
+        },
+    )
+    .await
+    .expect("conflict check should succeed");
+
+    assert!(conflicts.iter().any(|conflict| {
+        conflict.conflict_type == "personal" && conflict.id == created.schedule_id.to_string()
+    }));
 }

--- a/infra/rust-backend/tests/users_test.rs
+++ b/infra/rust-backend/tests/users_test.rs
@@ -192,8 +192,7 @@ async fn u5_nickname_check_self_allowed(pool: PgPool) {
     let _ = user_service::create_user(&pool, "test_self_nick", req).await;
 
     // 본인 닉네임 체크 → 사용 가능
-    let check =
-        user_service::check_nickname_available(&pool, "test_self_nick", "셀프닉넴").await;
+    let check = user_service::check_nickname_available(&pool, "test_self_nick", "셀프닉넴").await;
     assert!(check.is_ok());
     assert!(check.unwrap().available);
 }
@@ -205,8 +204,7 @@ async fn u5_nickname_check_taken_by_other(pool: PgPool) {
     let _ = user_service::create_user(&pool, "test_taken1", req).await;
 
     // 유저2가 같은 닉네임 체크 → 사용 불가
-    let check =
-        user_service::check_nickname_available(&pool, "test_taken2", "선점닉넴").await;
+    let check = user_service::check_nickname_available(&pool, "test_taken2", "선점닉넴").await;
     assert!(check.is_ok());
     assert!(!check.unwrap().available);
 }
@@ -248,8 +246,7 @@ async fn u8_get_other_user_no_common_group_rejected(pool: PgPool) {
     insert_test_user(&pool, "test_target", "대상자").await;
 
     // 공통 그룹 없이 타인 조회 → 거부
-    let result =
-        user_service::get_user_public(&pool, "test_requester", "test_target").await;
+    let result = user_service::get_user_public(&pool, "test_requester", "test_target").await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
 
@@ -299,8 +296,7 @@ async fn upload_profile_image_success(pool: PgPool) {
     let upload_req = UploadProfileImageRequest {
         image_path: "profile_images/test_upload/image.jpg".to_string(),
     };
-    let result =
-        user_service::upload_profile_image(&pool, "test_upload", upload_req).await;
+    let result = user_service::upload_profile_image(&pool, "test_upload", upload_req).await;
     assert!(result.is_ok());
 }
 
@@ -312,8 +308,7 @@ async fn upload_profile_image_empty_path_rejected(pool: PgPool) {
     let upload_req = UploadProfileImageRequest {
         image_path: "".to_string(),
     };
-    let result =
-        user_service::upload_profile_image(&pool, "test_upload_empty", upload_req).await;
+    let result = user_service::upload_profile_image(&pool, "test_upload_empty", upload_req).await;
     assert!(matches!(result, Err(AppError::BadRequest(_))));
 }
 


### PR DESCRIPTION
## Summary
- 일정(Schedule) 도메인 Firebase → Rust 마이그레이션 완료
- 그룹일정 + 개인일정 + 반복일정 3개 테이블 스키마 설계
- REST API 15개 엔드포인트 구현 (CRUD + 투표 + 조회 + 충돌감지 + LLM 추출)
- 64개 통합 테스트 통과
- iOS Feature Flag 연결 (`featureFlags.useRustAPI(.promises)`)

## Changes

### Rust Backend (`infra/rust-backend/`)
- `migrations/005_schedules.sql` — schedules, schedule_votes, recurring_schedules 테이블
- `src/models/schedule.rs` — 3 DB enum + 3 row struct + 16 DTO
- `src/services/schedule_service.rs` — 15 서비스 함수 (2300+ lines)
- `src/routes/schedules.rs` — 15 Axum 라우트 핸들러
- `tests/schedules_test.rs` — 64 통합 테스트

### iOS (`Projects/Clients/`)
- `ScheduleRustDataSource.swift` — Rust API DataSource (Response DTO → ScheduleModel)
- `ScheduleClient.swift` — Feature Flag 분기 추가 (12개 메서드)

### Docs (`.ai/`)
- `POSTGRES_SCHEMA.md` — schedules 스키마 + scheduleSlots 제거 근거
- `REST_API.md` — Schedules + Recurring Schedules API 상세

## Key Decisions
- 그룹/개인일정 단일 `schedules` 테이블 (schedule_type enum + CHECK)
- scheduleSlots 비정규화 제거 (SQL 인덱스 쿼리로 대체)
- votes Map → schedule_votes 정규화 테이블
- is_confirmed 비정규화 유지 (캘린더 쿼리 성능)
- Gemini API 직접 호출 (reqwest, Secret Manager 연동)

## Test plan
- [x] cargo test --test schedules_test (64/64 pass)
- [ ] Dev 환경 Cloud Run 배포 후 iOS Feature Flag 활성화 테스트
- [ ] 핵심 시나리오: 일정 생성 → 투표 → 확정 → 수정 → 삭제

🤖 Generated with [Claude Code](https://claude.com/claude-code)