### PR TITLE
fix: 브리핑 스케줄러 Rust cutover 및 FCM 실제 발송

### DIFF
--- a/.ai/REST_API.md
+++ b/.ai/REST_API.md
@@ -1457,10 +1457,10 @@ GET /api/v1/groups/{id}, POST /api/v1/groups/join 응답의 `data` 필드:
   ```
   - `totalDue`: 조회된 due 항목 수
   - `processed`: 실제 처리 시도 수
-  - `succeeded`: 브리핑 생성 + FCM 발송 성공
-  - `failed`: 처리 중 오류 발생 (next_dispatch_at은 갱신)
-  - `skipped`: Pro 박탈 등으로 건너뜀
+  - `succeeded`: 브리핑 생성 + FCM 발송 성공 (전체 성공 또는 부분 실패 포함; 부분 실패는 warn 로그)
+  - `failed`: 처리 중 오류 발생 또는 모든 토큰에 대한 FCM 발송 실패 (next_dispatch_at은 갱신)
+  - `skipped`: Pro 박탈, user_settings.briefing_notification_hour 불일치, FCM 토큰 미등록 등으로 건너뜀
   - `deleted`: briefing_subscriptions row 삭제 (notification_hour NULL 또는 Pro 상실)
 - 에러: 401 (X-Scheduler-Secret 불일치)
 
-*마지막 업데이트: 2026-04-08*
+*마지막 업데이트: 2026-04-26*

--- a/infra/rust-backend/src/routes/internal.rs
+++ b/infra/rust-backend/src/routes/internal.rs
@@ -1,12 +1,15 @@
+use std::sync::Arc;
+
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::routing::post;
-use axum::{Json, Router};
+use axum::{Extension, Json, Router};
 use chrono::Utc;
 use serde::Serialize;
 use sqlx::PgPool;
 
 use crate::errors::AppError;
+use crate::models::notification::PushSender;
 use crate::services::briefing_scheduler_service::{
     self, dispatch_due_briefings, verify_scheduler_secret,
 };
@@ -29,6 +32,7 @@ struct DispatchResponse {
 /// 인증: X-Scheduler-Secret 헤더 vs SCHEDULER_SECRET 환경변수
 async fn dispatch_briefings_handler(
     State(pool): State<PgPool>,
+    Extension(push_sender): Extension<Arc<dyn PushSender>>,
     headers: HeaderMap,
 ) -> Result<Json<DispatchResponse>, AppError> {
     // 1. X-Scheduler-Secret 헤더 추출
@@ -53,7 +57,7 @@ async fn dispatch_briefings_handler(
     }
 
     // 4. dispatch
-    let summary = dispatch_due_briefings(&pool, Utc::now(), 50).await?;
+    let summary = dispatch_due_briefings(&pool, push_sender.as_ref(), Utc::now(), 50).await?;
 
     // 5. 응답
     Ok(Json(DispatchResponse { summary }))

--- a/infra/rust-backend/src/routes/mod.rs
+++ b/infra/rust-backend/src/routes/mod.rs
@@ -83,7 +83,9 @@ pub fn create_router(pool: PgPool, config: &Config) -> Router {
         .merge(widget::widget_snapshot_router())
         .layer(axum::Extension(app_store_verifier))
         .layer(axum::Extension(public_live_activity_sender))
-        .layer(axum::Extension(public_push_sender));
+        .layer(axum::Extension(public_push_sender.clone()));
+
+    let internal_routes = internal::router().layer(axum::Extension(public_push_sender));
 
     Router::new()
         .merge(health::router()) // /health — 인증 불필요
@@ -91,7 +93,7 @@ pub fn create_router(pool: PgPool, config: &Config) -> Router {
         .merge(faq::router()) // /api/v1/faq — 인증 불필요
         .merge(groups::public_router()) // /api/v1/groups/preview — 인증 불필요
         .merge(places::router()) // /api/v1/places/* — 인증 불필요
-        .merge(internal::router()) // /api/v1/internal/* — 스케줄러 전용 (X-Scheduler-Secret 인증)
+        .merge(internal_routes) // /api/v1/internal/* — 스케줄러 전용 (X-Scheduler-Secret 인증)
         .merge(public_routes)
         .merge(authenticated_routes) // /api/v1/users/*, /api/v1/groups/* — 인증 필요
         .layer(axum::Extension(provider_verifier))

--- a/infra/rust-backend/src/services/briefing_scheduler_service.rs
+++ b/infra/rust-backend/src/services/briefing_scheduler_service.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use chrono::{DateTime, Duration, Utc};
 use sqlx::PgPool;
 
 use crate::errors::AppError;
+use crate::models::notification::{FcmMessage, NotificationType, PushSender};
 use crate::services::briefing_projection_service::compute_next_dispatch_at;
 use crate::services::briefing_service::{
     generate_briefing, BriefingLocation, GenerateBriefingRequest,
@@ -46,6 +49,7 @@ struct UserSettingsRow {
 /// due 항목 조회 + 브리핑 생성 + FCM 발송 + next_dispatch_at 갱신
 pub async fn dispatch_due_briefings(
     pool: &PgPool,
+    push_sender: &dyn PushSender,
     now: DateTime<Utc>,
     limit: i64,
 ) -> Result<DispatchSummary, AppError> {
@@ -170,21 +174,40 @@ pub async fn dispatch_due_briefings(
                         continue;
                     }
                     Ok(tokens) => {
-                        if !tokens.is_empty() {
+                        if tokens.is_empty() {
+                            tracing::info!(
+                                "[dispatch] no FCM tokens for user {}, skipping push",
+                                row.user_id
+                            );
+                            succeeded += 1;
+                        } else {
                             let token_list: Vec<String> =
                                 tokens.into_iter().map(|(t,)| t).collect();
-                            // TODO: FCM 발송 미구현 — PushSender 통합 후 실제 발송 예정
-                            // 현재는 stub으로 처리되므로 발송 시도를 기록만 한다.
+                            let mut data = HashMap::new();
+                            data.insert("type".to_string(), "daily_briefing".to_string());
+                            let message = FcmMessage {
+                                title: briefing.summary.clone(),
+                                body: briefing.detail.clone(),
+                                notification_type: NotificationType::System,
+                                data: Some(data),
+                                schedule_id: None,
+                                group_id: None,
+                                related_user_id: None,
+                            };
+                            let result =
+                                push_sender.send_multicast(&token_list, &message).await;
                             tracing::info!(
-                                "[dispatch] FCM push pending (stub) for user {}, {} token(s)",
+                                "[dispatch] FCM push for user {}: success={}, failed={}",
                                 row.user_id,
-                                token_list.len()
+                                result.success_count,
+                                result.failure_count
                             );
-                            let _fcm_result =
-                                send_briefing_push(&token_list, &briefing.summary).await;
+                            if result.success_count > 0 {
+                                succeeded += 1;
+                            } else {
+                                failed += 1;
+                            }
                         }
-
-                        succeeded += 1;
                     }
                 }
             }
@@ -199,16 +222,6 @@ pub async fn dispatch_due_briefings(
         skipped,
         deleted,
     })
-}
-
-/// 브리핑 FCM 발송 (실패해도 무시)
-async fn send_briefing_push(tokens: &[String], summary: &str) -> Result<(), AppError> {
-    // FCM sender가 없는 환경(테스트)에서는 그냥 Ok 반환
-    // 실제 환경에서는 Extension으로 주입된 PushSender를 사용하지만,
-    // scheduler는 내부 호출이므로 환경변수 기반 NoopPushSender로 폴백
-    let _ = tokens;
-    let _ = summary;
-    Ok(())
 }
 
 /// 스케줄러 전용 인증 검증 (constant-time 비교로 타이밍 어택 방어)

--- a/infra/rust-backend/src/services/briefing_scheduler_service.rs
+++ b/infra/rust-backend/src/services/briefing_scheduler_service.rs
@@ -179,10 +179,11 @@ pub async fn dispatch_due_briefings(
                                 "[dispatch] no FCM tokens for user {}, skipping push",
                                 row.user_id
                             );
-                            succeeded += 1;
+                            skipped += 1;
                         } else {
                             let token_list: Vec<String> =
                                 tokens.into_iter().map(|(t,)| t).collect();
+                            let total = token_list.len();
                             let mut data = HashMap::new();
                             data.insert("type".to_string(), "daily_briefing".to_string());
                             let message = FcmMessage {
@@ -197,15 +198,26 @@ pub async fn dispatch_due_briefings(
                             let result =
                                 push_sender.send_multicast(&token_list, &message).await;
                             tracing::info!(
-                                "[dispatch] FCM push for user {}: success={}, failed={}",
+                                "[dispatch] FCM push for user {}: success={}, failed={}, total={}",
                                 row.user_id,
                                 result.success_count,
-                                result.failure_count
+                                result.failure_count,
+                                total
                             );
-                            if result.success_count > 0 {
-                                succeeded += 1;
-                            } else {
+                            // 전부 실패한 경우만 failed. 부분 실패는 succeeded + warn.
+                            // NoopPushSender(success=0, failure=0)는 succeeded로 처리.
+                            if result.failure_count > 0 && result.success_count == 0 {
                                 failed += 1;
+                            } else {
+                                if result.failure_count > 0 {
+                                    tracing::warn!(
+                                        "[dispatch] partial FCM failure for user {}: {}/{} failed",
+                                        row.user_id,
+                                        result.failure_count,
+                                        total
+                                    );
+                                }
+                                succeeded += 1;
                             }
                         }
                     }

--- a/infra/rust-backend/src/services/user_settings_service.rs
+++ b/infra/rust-backend/src/services/user_settings_service.rs
@@ -411,7 +411,7 @@ pub async fn initialize_pro_defaults(
              briefing_style                = COALESCE(user_settings.briefing_style, 'friendly'),
              briefing_timezone             = COALESCE(user_settings.briefing_timezone, EXCLUDED.briefing_timezone),
              briefing_language             = COALESCE(user_settings.briefing_language, 'ko'),
-             briefing_available_transports = COALESCE(user_settings.briefing_available_transports, '{transit,car}'),
+             briefing_available_transports = user_settings.briefing_available_transports,
              updated_at                    = NOW()",
     )
     .bind(user_id)

--- a/infra/rust-backend/src/services/user_settings_service.rs
+++ b/infra/rust-backend/src/services/user_settings_service.rs
@@ -407,12 +407,11 @@ pub async fn initialize_pro_defaults(
               updated_at)
          VALUES ($1, 8, 'friendly', $2, 'ko', 0, '{transit,car}', NOW())
          ON CONFLICT (user_id) DO UPDATE SET
-             briefing_notification_hour    = 8,
-             briefing_style                = 'friendly',
-             briefing_timezone             = EXCLUDED.briefing_timezone,
-             briefing_language             = 'ko',
-             conflict_threshold_min        = 0,
-             briefing_available_transports = '{transit,car}',
+             briefing_notification_hour    = COALESCE(user_settings.briefing_notification_hour, 8),
+             briefing_style                = COALESCE(user_settings.briefing_style, 'friendly'),
+             briefing_timezone             = COALESCE(user_settings.briefing_timezone, EXCLUDED.briefing_timezone),
+             briefing_language             = COALESCE(user_settings.briefing_language, 'ko'),
+             briefing_available_transports = COALESCE(user_settings.briefing_available_transports, '{transit,car}'),
              updated_at                    = NOW()",
     )
     .bind(user_id)

--- a/infra/rust-backend/tests/briefing_scheduler_test.rs
+++ b/infra/rust-backend/tests/briefing_scheduler_test.rs
@@ -1,5 +1,6 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use promiso_backend::push::NoopPushSender;
 use promiso_backend::services::briefing_scheduler_service::{
     dispatch_due_briefings, verify_scheduler_secret,
 };
@@ -116,7 +117,7 @@ async fn dispatch_processes_due_items(pool: PgPool) {
     insert_subscription(&pool, "sched_due_1", -60).await;
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     // due 항목이 1개이므로 total_due >= 1
     assert!(summary.total_due >= 1);
@@ -133,7 +134,7 @@ async fn dispatch_skips_future_items(pool: PgPool) {
     insert_subscription(&pool, "sched_future_1", 3600).await;
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     assert_eq!(summary.total_due, 0);
     assert_eq!(summary.processed, 0);
@@ -150,7 +151,7 @@ async fn dispatch_respects_limit(pool: PgPool) {
     }
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 1).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 1).await.unwrap();
 
     // limit=1이면 최대 1개만 처리
     assert!(summary.processed <= 1);
@@ -172,7 +173,7 @@ async fn dispatch_advances_next_dispatch_at(pool: PgPool) {
             .await
             .expect("row should exist before dispatch");
 
-    dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     // 처리 후 next_dispatch_at이 갱신되었거나 행이 삭제되어야 한다
     let after_row: Option<(chrono::DateTime<chrono::Utc>,)> =
@@ -216,7 +217,7 @@ async fn dispatch_deletes_when_no_next(pool: PgPool) {
     .expect("Failed to insert subscription");
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     // 행이 삭제되어야 한다
     let row_count: (i64,) =
@@ -241,7 +242,7 @@ async fn dispatch_skips_non_pro_users(pool: PgPool) {
     insert_subscription(&pool, "sched_nonpro_1", -60).await;
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     // Pro 아닌 유저는 skipped 카운트에 반영 (SC-2, SC-3)
     assert!(summary.skipped >= 1);
@@ -269,7 +270,7 @@ async fn dispatch_returns_correct_summary(pool: PgPool) {
     insert_subscription(&pool, "sched_summary_future_1", 3600).await;
 
     let now = chrono::Utc::now();
-    let summary = dispatch_due_briefings(&pool, now, 10).await.unwrap();
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, now, 10).await.unwrap();
 
     // due 항목: 2개 (pro 1 + free 1)
     assert_eq!(summary.total_due, 2);

--- a/infra/rust-backend/tests/briefing_scheduler_test.rs
+++ b/infra/rust-backend/tests/briefing_scheduler_test.rs
@@ -1,11 +1,56 @@
+use std::sync::Arc;
+
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use promiso_backend::models::notification::{FcmMessage, PushResult, PushSender};
 use promiso_backend::push::NoopPushSender;
 use promiso_backend::services::briefing_scheduler_service::{
     dispatch_due_briefings, verify_scheduler_secret,
 };
 use sqlx::PgPool;
 use tower::ServiceExt;
+
+// 테스트용 모의 PushSender — 결과를 미리 지정해 카운팅 분기를 검증한다.
+struct MockPushSender {
+    success_count: i32,
+    failure_count: i32,
+}
+
+#[async_trait::async_trait]
+impl PushSender for MockPushSender {
+    async fn send_multicast(&self, _tokens: &[String], _message: &FcmMessage) -> PushResult {
+        PushResult {
+            success: self.failure_count == 0,
+            success_count: self.success_count,
+            failure_count: self.failure_count,
+            delivered_tokens: Vec::new(),
+        }
+    }
+}
+
+/// FCM 토큰 등록 — devices + notification_endpoints
+async fn insert_fcm_token(pool: &PgPool, user_id: &str, token: &str) {
+    let device_id: (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO devices (user_id, device_id, platform, last_active_at)
+         VALUES ($1, $2, 'ios', NOW())
+         RETURNING id",
+    )
+    .bind(user_id)
+    .bind(format!("device-{user_id}"))
+    .fetch_one(pool)
+    .await
+    .expect("Failed to insert device");
+
+    sqlx::query(
+        "INSERT INTO notification_endpoints (device_id, provider, token)
+         VALUES ($1, 'fcm', $2)",
+    )
+    .bind(device_id.0)
+    .bind(token)
+    .execute(pool)
+    .await
+    .expect("Failed to insert notification_endpoint");
+}
 
 // ============================================================
 // 순수 함수 테스트
@@ -276,8 +321,8 @@ async fn dispatch_returns_correct_summary(pool: PgPool) {
     assert_eq!(summary.total_due, 2);
     // processed: 2개 모두 처리 시도
     assert_eq!(summary.processed, 2);
-    // skipped: 1개 (non-pro)
-    assert_eq!(summary.skipped, 1);
+    // skipped: 2개 (non-pro 1 + pro지만 FCM 토큰 없음 1)
+    assert_eq!(summary.skipped, 2);
     // succeeded + failed + skipped == processed
     assert_eq!(
         summary.succeeded + summary.failed + summary.skipped,
@@ -286,12 +331,103 @@ async fn dispatch_returns_correct_summary(pool: PgPool) {
 }
 
 // ============================================================
+// FCM 발송 카운팅 분기 테스트 (Mock PushSender 사용)
+// ============================================================
+
+#[sqlx::test(migrations = "./migrations")]
+async fn dispatch_counts_no_tokens_as_skipped(pool: PgPool) {
+    insert_user(&pool, "fcm_no_token").await;
+    insert_pro_entitlement(&pool, "fcm_no_token").await;
+    insert_user_settings(&pool, "fcm_no_token").await;
+    insert_subscription(&pool, "fcm_no_token", -60).await;
+    // FCM 토큰 미등록
+
+    let mock = MockPushSender {
+        success_count: 0,
+        failure_count: 0,
+    };
+    let summary = dispatch_due_briefings(&pool, &mock, chrono::Utc::now(), 10)
+        .await
+        .unwrap();
+
+    // 토큰이 없으므로 발송 시도 자체가 없어야 하고, skipped로 집계되어야 한다.
+    assert_eq!(summary.skipped, 1);
+    assert_eq!(summary.succeeded, 0);
+    assert_eq!(summary.failed, 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn dispatch_counts_partial_failure_as_succeeded(pool: PgPool) {
+    insert_user(&pool, "fcm_partial").await;
+    insert_pro_entitlement(&pool, "fcm_partial").await;
+    insert_user_settings(&pool, "fcm_partial").await;
+    insert_subscription(&pool, "fcm_partial", -60).await;
+    insert_fcm_token(&pool, "fcm_partial", "token-a").await;
+
+    let mock = MockPushSender {
+        success_count: 1,
+        failure_count: 1,
+    };
+    let summary = dispatch_due_briefings(&pool, &mock, chrono::Utc::now(), 10)
+        .await
+        .unwrap();
+
+    // 부분 실패는 succeeded로 집계 (전부 실패만 failed).
+    assert_eq!(summary.succeeded, 1);
+    assert_eq!(summary.failed, 0);
+    assert_eq!(summary.skipped, 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn dispatch_counts_total_failure_as_failed(pool: PgPool) {
+    insert_user(&pool, "fcm_all_fail").await;
+    insert_pro_entitlement(&pool, "fcm_all_fail").await;
+    insert_user_settings(&pool, "fcm_all_fail").await;
+    insert_subscription(&pool, "fcm_all_fail", -60).await;
+    insert_fcm_token(&pool, "fcm_all_fail", "token-a").await;
+
+    let mock = MockPushSender {
+        success_count: 0,
+        failure_count: 1,
+    };
+    let summary = dispatch_due_briefings(&pool, &mock, chrono::Utc::now(), 10)
+        .await
+        .unwrap();
+
+    assert_eq!(summary.failed, 1);
+    assert_eq!(summary.succeeded, 0);
+    assert_eq!(summary.skipped, 0);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn dispatch_counts_noop_pushsender_as_succeeded(pool: PgPool) {
+    // NoopPushSender는 success=0, failure=0 을 반환한다.
+    // 운영 환경에서 FCM 미설정 시 폴백으로 사용되므로
+    // 모든 dispatch가 failed로 잡히지 않아야 한다.
+    insert_user(&pool, "fcm_noop").await;
+    insert_pro_entitlement(&pool, "fcm_noop").await;
+    insert_user_settings(&pool, "fcm_noop").await;
+    insert_subscription(&pool, "fcm_noop", -60).await;
+    insert_fcm_token(&pool, "fcm_noop", "token-a").await;
+
+    let summary = dispatch_due_briefings(&pool, &NoopPushSender, chrono::Utc::now(), 10)
+        .await
+        .unwrap();
+
+    assert_eq!(summary.succeeded, 1);
+    assert_eq!(summary.failed, 0);
+}
+
+// ============================================================
 // 라우트 테스트
 // ============================================================
 
 fn app_with_scheduler_secret(pool: PgPool, secret: &str) -> axum::Router {
     std::env::set_var("SCHEDULER_SECRET", secret);
-    promiso_backend::routes::internal::router().with_state(pool)
+    let push_sender: Arc<dyn PushSender> = Arc::new(NoopPushSender);
+    promiso_backend::routes::internal::router()
+        .layer(axum::Extension(push_sender))
+        .with_state(pool)
 }
 
 #[sqlx::test(migrations = "./migrations")]


### PR DESCRIPTION
## Summary

- 브리핑 dispatch가 `send_briefing_push` stub 때문에 실제 FCM 푸시가 발송되지 않던 문제 수정 — `PushSender.send_multicast`로 실제 호출
- `routes/internal`에 `Extension<Arc<dyn PushSender>>` 주입 경로 추가 (기존엔 internal 라우트에 push_sender Extension이 부착되지 않음)
- `initialize_pro_defaults`의 `ON CONFLICT DO UPDATE` 분기를 `COALESCE(기존값, 기본값)` 패턴으로 변경 — 재호출 시 사용자가 설정한 알림 시간을 8시로 강제 리셋하던 부수 버그 수정

## 인프라 변경 (별도 적용 완료, 이 PR에 포함되지 않음)

세 환경(Dev/Stage/Prod) 모두에 다음 작업을 이미 적용했습니다:

| 작업 | 상태 |
|------|------|
| `SCHEDULER_SECRET` Secret Manager 시크릿 생성 + Cloud Run 마운트 | ✅ |
| `cloud-scheduler-invoker` 서비스 계정 생성 + `roles/run.invoker` 부여 | ✅ |
| 새 Cloud Scheduler 잡 `rust-briefing-dispatch` 생성 (`0 * * * *` UTC → Rust `/api/v1/internal/briefing/dispatch`, OIDC + X-Scheduler-Secret 인증) | ✅ |
| 기존 `firebase-schedule-scheduledBriefingDispatch-asia-northeast3` 잡 PAUSED | ✅ |
| Cloud Run 신규 리비전 배포 | Dev `00043-wr2`, Stage `00008-4wg`, Prod `00008-pkm` |
| 수동 트리거 → 200 OK 확인 | ✅ |

## 배경

- Cloud Scheduler가 여전히 Firebase Functions의 `scheduledBriefingDispatch`를 가리키고 있어, Firestore `briefingSubscriptions`(마이그레이션 시점에 8시 기본값으로 굳음)를 기준으로 dispatch — 모든 사용자가 오전 8시에 발송되는 증상
- iOS 클라이언트 설정 변경은 이미 Rust → PostgreSQL `user_settings`로만 흐르므로 시간 변경이 Firestore에 반영 안 됨
- Rust 측은 `/api/v1/internal/briefing/dispatch` 엔드포인트는 있었지만 cron 트리거가 없었고, FCM 발송 로직이 stub 상태였음

## Test plan

- [x] `cargo check --tests` 통과
- [x] Dev/Stage/Prod 수동 스케줄러 트리거 → 200 OK
- [ ] 다음 정시 이후 본인 계정 푸시 도착 여부 확인 (KST 9시, 10시 등 due 사용자가 있는 시점)
- [ ] iOS 앱에서 브리핑 시간을 변경 → 변경한 시간에 푸시 도착하는지 확인

## 후속 작업 (이 PR 외)

- 1주 안정 운영 후 `firebase-schedule-scheduledBriefingDispatch-asia-northeast3` 잡 삭제
- Firebase Functions의 `scheduledBriefingDispatch`/`executeBriefingNotification`/`weather` 코드 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)