### PR TITLE
Fix prod subscription and widget config

### DIFF
--- a/.ai/REST_API.md
+++ b/.ai/REST_API.md
@@ -14,10 +14,31 @@
 | Method | Path | 설명 |
 |--------|------|------|
 | GET | `/health` | 서버 + DB 상태 확인 |
+| GET | `/api/v1/app-config` | 앱 강제 업데이트/법적 링크 등 운영 설정 조회 |
 | GET | `/api/v1/faq` | FAQ 목록 조회 (Postgres `faqs` 테이블) |
 | POST | `/api/v1/live-activity/widget/eta` | Widget ETA broadcast (X-User-Id/X-Auth-Token 필수, widget token이면 X-Device-Id 필요) |
 | POST | `/api/v1/live-activity/widget/vote` | Widget vote 응답 (X-User-Id/X-Auth-Token 필수, widget token이면 X-Device-Id 필요) |
+| POST | `/api/v1/subscriptions/apple-notifications` | Apple Server Notifications V2 webhook |
 | GET | `/api/v1/places/search?q=&size=` | Kakao 장소 검색 |
+
+### GET /api/v1/app-config
+
+- 설명: 앱 시작 시 운영 설정 조회. PostgreSQL `app_config` singleton row 기준.
+- 인증: 불필요
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "forceUpdateVersion": "0.0.0",
+      "recommendedVersion": "0.0.0",
+      "appStoreURL": "https://apps.apple.com/kr/app/id6757733720",
+      "privacyPolicyURL": "https://www.notion.so/...",
+      "termsOfServiceURL": "https://www.notion.so/...",
+      "supportEmail": "support@promiso.app",
+      "updatedAt": "ISO8601"
+    }
+  }
+  ```
 
 ### GET /api/v1/faq
 
@@ -151,6 +172,93 @@
   - `briefing_available_transports`: `["transit", "car"]`
 - 사이드이펙트: `briefing_subscriptions` projection 자동 재계산 (US-12)
 - 응답 200: UserSettingsResponse (GET과 동일 구조)
+
+## Subscriptions (인증 필요)
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | `/api/v1/subscriptions/verify-purchase` | StoreKit transaction JWS 서버 검증 |
+| GET | `/api/v1/subscriptions/status` | 현재 사용자의 App Store 구독 원본 상태 조회 |
+| GET | `/api/v1/subscriptions/entitlement` | 구독 + override 합산 Pro 권한 조회 |
+
+### POST /api/v1/subscriptions/verify-purchase
+
+- 설명: 앱에서 StoreKit 구매/복원 후 받은 transaction JWS를 App Store 서버 검증하고 `subscriptions`, `subscription_owners`, `entitlements`를 갱신
+- 인증: 필수
+- 요청:
+  ```json
+  {
+    "transactionJWS": "signed-jws",
+    "productId": "com.promiso.pro.monthly",
+    "forceTransfer": false
+  }
+  ```
+  - `forceTransfer`: 다른 계정에 묶인 originalTransactionId를 현재 계정으로 이전할 때만 true
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "success": true,
+      "subscriptionStatus": {
+        "status": "subscribed",
+        "productId": "com.promiso.pro.monthly",
+        "originalTransactionId": "1000000000000000",
+        "expirationDate": "ISO8601",
+        "purchaseDate": "ISO8601",
+        "latestAppStoreSignedDate": 1710000000000,
+        "latestTransactionId": "1000000000000001",
+        "lastNotificationType": null,
+        "lastOfferType": null,
+        "lastOfferIdentifier": null,
+        "updatedAt": "ISO8601"
+      }
+    }
+  }
+  ```
+- 에러: 400 (필수값 누락/상품 불일치), 409 (다른 계정 소유), 412 (App Store 검증 실패)
+
+### GET /api/v1/subscriptions/status
+
+- 설명: 현재 사용자의 App Store 구독 원본 상태 조회. override는 합산하지 않음.
+- 인증: 필수
+- 응답 200: `SubscriptionStatusResponse`
+  - `status`: `"none"` | `"subscribed"` | `"lifetime"` | `"gracePeriod"` | `"expired"` | `"revoked"`
+
+### GET /api/v1/subscriptions/entitlement
+
+- 설명: 앱이 실제 Pro 여부를 판단할 때 사용하는 통합 read model 조회
+- 인증: 필수
+- 응답 200:
+  ```json
+  {
+    "data": {
+      "hasPro": true,
+      "source": "subscription",
+      "subscriptionStatus": "subscribed",
+      "productId": "com.promiso.pro.monthly",
+      "expirationDate": "ISO8601",
+      "overrideActive": false,
+      "overrideExpiresAt": null,
+      "overrideType": null,
+      "lastOfferType": null,
+      "lastOfferIdentifier": null,
+      "updatedAt": "ISO8601"
+    }
+  }
+  ```
+  - `source`: `"subscription"` | `"override"` | `"none"`
+  - 활성 Pro 상태: `subscribed`, `lifetime`, `gracePeriod`, 또는 활성 override
+
+### POST /api/v1/subscriptions/apple-notifications
+
+- 설명: Apple Server Notifications V2 webhook. `signedPayload`를 검증하고 owner index 기준으로 구독 상태를 갱신.
+- 인증: 불필요 (Apple JWS 검증으로 신뢰)
+- 요청:
+  ```json
+  { "signedPayload": "signed-jws" }
+  ```
+- 응답 200: `{ "data": { "success": true } }`
+- 운영: App Store Connect Server Notification URL은 이 endpoint로 설정
 
 ## Groups
 

--- a/.github/workflows/deploy-rust.yml
+++ b/.github/workflows/deploy-rust.yml
@@ -123,6 +123,18 @@ jobs:
           FIREBASE_PROJECT_ID: promiso-dev
         run: cargo test --lib
 
+      - name: Run config regression test
+        working-directory: infra/rust-backend
+        run: cargo test --test config_test
+
+      - name: Run subscription integration test
+        working-directory: infra/rust-backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost/promiso_test
+          DATABASE_POOL_URL: postgresql://postgres:postgres@localhost/promiso_test
+          FIREBASE_PROJECT_ID: promiso-dev
+        run: cargo test --test subscriptions_test -- --test-threads=1
+
       - name: Run data migration integration test
         working-directory: infra/rust-backend
         env:

--- a/Projects/Shared/Sources/Constants/AppConstants.swift
+++ b/Projects/Shared/Sources/Constants/AppConstants.swift
@@ -142,7 +142,11 @@ public enum AppConstants {
   // MARK: - Network
 
   public enum Network {
-    private static let fallbackRustAPIURLString = "https://promiso-api-809932911903.asia-northeast3.run.app"
+    public static let devRustAPIURLString = "https://promiso-api-809932911903.asia-northeast3.run.app"
+    public static let stageRustAPIURLString = "https://promiso-api-511041416523.asia-northeast3.run.app"
+    public static let prodRustAPIURLString = "https://promiso-api-367716701610.asia-northeast3.run.app"
+
+    private static let fallbackRustAPIURLString = devRustAPIURLString
 
     public static var rustAPIURL: URL {
       if let urlString = Bundle.main.object(forInfoDictionaryKey: "RUST_API_URL") as? String,

--- a/Projects/Shared/Sources/LiveActivity/ScheduleActivityAttributes.swift
+++ b/Projects/Shared/Sources/LiveActivity/ScheduleActivityAttributes.swift
@@ -291,8 +291,19 @@ public enum LiveActivityIntentKey {
 
   /// Rust API Base URL
   public static var rustAPIBaseURL: String {
-    UserDefaults(suiteName: suiteName)?.string(forKey: rustApiBaseUrlKey)
-      ?? "https://promiso-api-809932911903.asia-northeast3.run.app"
+    if let savedURL = UserDefaults(suiteName: suiteName)?.string(forKey: rustApiBaseUrlKey),
+       !savedURL.isEmpty {
+      return savedURL
+    }
+
+    let bundleId = Bundle.main.bundleIdentifier ?? ""
+    if bundleId.contains(".stage") {
+      return "https://promiso-api-511041416523.asia-northeast3.run.app"
+    }
+    if bundleId.contains(".dev") {
+      return "https://promiso-api-809932911903.asia-northeast3.run.app"
+    }
+    return "https://promiso-api-367716701610.asia-northeast3.run.app"
   }
 }
 

--- a/Projects/Shared/Sources/LiveActivity/ScheduleActivityAttributes.swift
+++ b/Projects/Shared/Sources/LiveActivity/ScheduleActivityAttributes.swift
@@ -297,13 +297,13 @@ public enum LiveActivityIntentKey {
     }
 
     let bundleId = Bundle.main.bundleIdentifier ?? ""
-    if bundleId.contains(".stage") {
-      return "https://promiso-api-511041416523.asia-northeast3.run.app"
-    }
     if bundleId.contains(".dev") {
-      return "https://promiso-api-809932911903.asia-northeast3.run.app"
+      return AppConstants.Network.devRustAPIURLString
     }
-    return "https://promiso-api-367716701610.asia-northeast3.run.app"
+    if bundleId.contains(".stage") {
+      return AppConstants.Network.stageRustAPIURLString
+    }
+    return AppConstants.Network.prodRustAPIURLString
   }
 }
 

--- a/Projects/Shared/Sources/Widget/WidgetDataManager.swift
+++ b/Projects/Shared/Sources/Widget/WidgetDataManager.swift
@@ -165,11 +165,9 @@ public enum WidgetDataManager {
   private static let manualRefreshTTL: TimeInterval = 15.0
 
   /// Rust API 기본 URL
-  #if DEBUG
-  private static let rustBaseURL = "https://promiso-api-809932911903.asia-northeast3.run.app"
-  #else
-  private static let rustBaseURL = "https://promiso-api-809932911903.asia-northeast3.run.app"
-  #endif
+  private static var rustBaseURL: String {
+    LiveActivityIntentKey.rustAPIBaseURL
+  }
 
   private static var defaults: UserDefaults? {
     UserDefaults(suiteName: suiteName)

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -26,6 +26,7 @@ Promiso 프로젝트의 GitHub Actions 기반 CI/CD 파이프라인 설명입니
 | **QA Nightly** | 평일 18:00 KST + 수동 실행 | release 기준 curated QA | Stage / Web / Functions |
 | **QA Weekly** | 매주 월요일 10:00 KST + 수동 실행 | release 기준 넓은 회귀 QA | Stage / Web / Functions |
 | **Deploy iOS** | 수동 (workflow_dispatch) | TestFlight 배포 | Stage / Prod |
+| **Deploy Rust Backend** | 수동 (workflow_dispatch) | Cloud Run Rust API 배포 | Dev / Stage / Prod |
 | **Deploy Firebase** | 수동 (workflow_dispatch) | Firebase 배포 (Functions/Rules) | Stage / Prod |
 | **Deploy Firebase Stage (Auto)** | `push` to `release/**` + Firebase 경로 변경 | Stage 자동 배포 | Stage |
 | **Gemini Review Slack** | `pull_request_review` submitted | Gemini 리뷰 Slack 알림 | N/A |

--- a/infra/firebase/functions/src/config/index.ts
+++ b/infra/firebase/functions/src/config/index.ts
@@ -109,7 +109,7 @@ export const APP_STORE_BUNDLE_ID = getAPNsBundleId();
  */
 export const APP_STORE_APPLE_ID = getCurrentEnvironment() ===
   FirestoreEnvironment.Release ?
-  1625074042 :
+  6757733720 :
   undefined;
 
 export const APNS_BUNDLE_ID = APP_STORE_BUNDLE_ID;

--- a/infra/firebase/functions/test/config.test.ts
+++ b/infra/firebase/functions/test/config.test.ts
@@ -1,0 +1,33 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+const originalProjectId = process.env.GCLOUD_PROJECT;
+
+describe("functions config", () => {
+  afterEach(() => {
+    process.env.GCLOUD_PROJECT = originalProjectId;
+    jest.resetModules();
+  });
+
+  it("uses the Promiso App Store appAppleId in release", async () => {
+    process.env.GCLOUD_PROJECT = "promiso-prod";
+    jest.resetModules();
+
+    const config = await import("../src/config");
+
+    expect(config.APP_STORE_APPLE_ID).toBe(6757733720);
+  });
+
+  it("does not set appAppleId outside release", async () => {
+    process.env.GCLOUD_PROJECT = "promiso-stage";
+    jest.resetModules();
+
+    const config = await import("../src/config");
+
+    expect(config.APP_STORE_APPLE_ID).toBeUndefined();
+  });
+});

--- a/infra/rust-backend/src/config/mod.rs
+++ b/infra/rust-backend/src/config/mod.rs
@@ -59,7 +59,7 @@ impl Config {
                 .and_then(|value| value.parse().ok())
                 .or_else(|| {
                     if apns_environment == "production" {
-                        Some(1625074042)
+                        Some(6757733720)
                     } else {
                         None
                     }

--- a/infra/rust-backend/tests/config_test.rs
+++ b/infra/rust-backend/tests/config_test.rs
@@ -1,0 +1,13 @@
+use promiso_backend::config::Config;
+
+#[test]
+fn production_config_defaults_to_promiso_app_store_apple_id() {
+    std::env::set_var("DATABASE_URL", "postgresql://localhost/promiso_test");
+    std::env::set_var("FIREBASE_PROJECT_ID", "promiso-prod");
+    std::env::set_var("APNS_ENVIRONMENT", "production");
+    std::env::remove_var("APP_STORE_APPLE_ID");
+
+    let config = Config::from_env();
+
+    assert_eq!(config.app_store_apple_id, Some(6757733720));
+}


### PR DESCRIPTION
## Summary
- Fix prod App Store appAppleId for Rust backend and Firebase Functions subscription verification, and route widgets/LiveActivity to the correct Rust API URL by environment.
- Add config regression tests plus Rust deploy subscription/config test coverage, then document Rust app-config/subscription endpoints and deploy workflow.

## 변경 유형
- [ ] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [x] chore: 설정, 빌드 등 기타 변경
- [x] docs: 문서 수정
- [x] test: 테스트 추가/수정

## 변경 파일
- `infra/rust-backend/src/config/mod.rs`, `infra/rust-backend/tests/config_test.rs`
- `infra/firebase/functions/src/config/index.ts`, `infra/firebase/functions/test/config.test.ts`
- `Projects/Shared/Sources/LiveActivity/ScheduleActivityAttributes.swift`, `Projects/Shared/Sources/Widget/WidgetDataManager.swift`
- `.github/workflows/deploy-rust.yml`, `.ai/REST_API.md`, `docs/CI_CD.md`

## 스크린샷 (UI 변경 시)
N/A

## Test plan
- [x] `cargo test --manifest-path infra/rust-backend/Cargo.toml --test config_test`
- [x] `cargo test --manifest-path infra/rust-backend/Cargo.toml --test subscriptions_test -- --test-threads=1`
- [x] `npm --prefix infra/firebase/functions test -- --runInBand test/config.test.ts`
- [x] `npm --prefix infra/firebase/functions test -- --runInBand test/subscription.test.ts`
- [x] `npm --prefix infra/firebase/functions run build`
- [x] `tuist build PromisoDev -- -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -skipPackagePluginValidation`
- [x] `git diff --check`
- [x] Production TestFlight deploy succeeded for `1.4.0 (2604260514009)`

## 관련 이슈
N/A
