### PR TITLE
fix: 배포 워크플로우에 SCHEDULER_SECRET 추가

### DIFF
--- a/.github/workflows/deploy-rust.yml
+++ b/.github/workflows/deploy-rust.yml
@@ -185,7 +185,7 @@ jobs:
             --region asia-northeast3 \
             --allow-unauthenticated \
             --set-env-vars "FIREBASE_PROJECT_ID=${{ needs.setup.outputs.project_id }},RUST_LOG=info,APNS_KEY_ID=4CHBHPYY75,APNS_TEAM_ID=BAC795627G,APNS_BUNDLE_ID=${{ needs.setup.outputs.apns_bundle_id }},APNS_ENVIRONMENT=${{ needs.setup.outputs.apns_environment }},GCS_UPLOAD_BUCKET=${{ needs.setup.outputs.gcs_bucket }}" \
-            --set-secrets "DATABASE_URL=DATABASE_URL:latest,DATABASE_POOL_URL=DATABASE_POOL_URL:latest,AUTH_JWT_SECRET=AUTH_JWT_SECRET:latest,FIREBASE_SERVICE_ACCOUNT_JSON=FIREBASE_SERVICE_ACCOUNT_JSON:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,WIDGET_JWT_SECRET=WIDGET_JWT_SECRET:latest,APNS_AUTH_KEY=APNS_AUTH_KEY:latest,KAKAO_REST_API_KEY=KAKAO_REST_API_KEY:latest,ODSAY_API_KEY=ODSAY_API_KEY:latest" \
+            --set-secrets "DATABASE_URL=DATABASE_URL:latest,DATABASE_POOL_URL=DATABASE_POOL_URL:latest,AUTH_JWT_SECRET=AUTH_JWT_SECRET:latest,FIREBASE_SERVICE_ACCOUNT_JSON=FIREBASE_SERVICE_ACCOUNT_JSON:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,WIDGET_JWT_SECRET=WIDGET_JWT_SECRET:latest,APNS_AUTH_KEY=APNS_AUTH_KEY:latest,KAKAO_REST_API_KEY=KAKAO_REST_API_KEY:latest,ODSAY_API_KEY=ODSAY_API_KEY:latest,SCHEDULER_SECRET=SCHEDULER_SECRET:latest" \
             --quiet
 
       - name: Verify deployment


### PR DESCRIPTION
## Summary
- `deploy-rust.yml`의 `--set-secrets` 목록에서 `SCHEDULER_SECRET`이 누락되어 있어 Cloud Run에 환경변수가 마운트되지 않았음
- 그 결과 `/api/v1/internal/briefing/dispatch`가 `SCHEDULER_SECRET not configured` 에러로 매시간 500 반환 (24시간째)
- 1.4.0의 핵심 기능인 "브리핑 스케줄러 Rust cutover"(#304)가 프로덕션에서 사실상 미작동 상태였음

## 조치
1. **수동 hotfix (이미 적용 완료)**: dev/stage/prod 모두 `gcloud run services update --update-secrets=SCHEDULER_SECRET=SCHEDULER_SECRET:latest`로 즉시 복구
   - prod: revision `promiso-api-00010-48s`
   - stage: revision `promiso-api-00010-hzh`
   - dev: revision `promiso-api-00045-dj5`
2. **워크플로우 수정 (이 PR)**: 다음 배포 시 `--set-secrets`가 SCHEDULER_SECRET을 다시 누락시키지 않도록 목록에 추가

## 검증
세 환경 모두 Scheduler 수동 트리거로 200 OK 확인:
- promiso-dev: `2026-04-27T04:26:27Z` → 200
- promiso-stage: `2026-04-27T04:26:28Z` → 200
- promiso-prod: `2026-04-27T04:26:30Z` → 200

## Test plan
- [x] dev/stage/prod Cloud Run 환경변수 마운트 확인
- [x] Cloud Scheduler 수동 트리거 200 OK 응답 확인
- [ ] 다음 정각 자동 트리거 결과 확인 (매시 0분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)