### PR TITLE
fix: 구독 만료 처리 — 서버를 SSOT로 정렬

### DIFF
--- a/Projects/Clients/Sources/Clients/SubscriptionClient.swift
+++ b/Projects/Clients/Sources/Clients/SubscriptionClient.swift
@@ -27,9 +27,6 @@ public struct SubscriptionClient: Sendable {
   /// 현재 구독 상태 조회
   public var fetchStatus: @Sendable () async throws -> SubscriptionStatus
 
-  /// 로컬 StoreKit 상태만 조회 (AppStore.sync() 없이 Transaction.currentEntitlements 사용)
-  public var fetchLocalStatus: @Sendable () async throws -> SubscriptionStatus
-
   /// 서버에 구매 검증 요청
   public var verifyPurchase: @Sendable (_ transactionJWS: String, _ productId: String, _ forceTransfer: Bool) async throws -> SubscriptionStatus
 
@@ -60,7 +57,6 @@ extension SubscriptionClient: TestDependencyKey {
     restore: unimplemented("\(Self.self).restore", placeholder: .none),
     restoreWithReceipt: unimplemented("\(Self.self).restoreWithReceipt", placeholder: RestoreResult(jwsString: nil, productId: nil, localStatus: .none)),
     fetchStatus: unimplemented("\(Self.self).fetchStatus", placeholder: .none),
-    fetchLocalStatus: unimplemented("\(Self.self).fetchLocalStatus", placeholder: .none),
     verifyPurchase: unimplemented("\(Self.self).verifyPurchase", placeholder: .none),
     checkIntroOfferEligibility: unimplemented("\(Self.self).checkIntroOfferEligibility", placeholder: false),
     unifiedStatusStream: unimplemented("\(Self.self).unifiedStatusStream", placeholder: .finished),
@@ -118,7 +114,6 @@ extension SubscriptionClient: TestDependencyKey {
     fetchStatus: {
       return .none
     },
-    fetchLocalStatus: { .subscribed(productType: .yearly, expirationDate: Date().addingTimeInterval(30 * 24 * 3600)) },
     verifyPurchase: { _, _, _ in
       try await Task.sleep(for: .seconds(1.0))
       return .subscribed(productType: .monthly, expirationDate: Date().addingTimeInterval(30 * 24 * 3600))
@@ -173,9 +168,6 @@ extension SubscriptionClient: DependencyKey {
       },
       fetchStatus: {
         return try await rustDataSource.fetchStatus()
-      },
-      fetchLocalStatus: {
-        try await dataSource.fetchCurrentStatus()
       },
       verifyPurchase: { jwsString, productId, forceTransfer in
         return try await rustDataSource.verifyPurchase(

--- a/Projects/Features/ProPlanFeature/Tests/Sources/ProPlanFeatureTests.swift
+++ b/Projects/Features/ProPlanFeature/Tests/Sources/ProPlanFeatureTests.swift
@@ -519,19 +519,9 @@ struct ProPlanFeatureTests {
   func onAppear_serverSubscribedExpiredDate_keepsPro() async {
     let pastDate = Date().addingTimeInterval(-24 * 3600) // 1일 전
     let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
-    actor CallCounter {
-      private var count = 0
-      func increment() { count += 1 }
-      func value() -> Int { count }
-    }
-    let localStatusCounter = CallCounter()
 
     let store = makeStore {
       $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = {
-        await localStatusCounter.increment()
-        return .none
-      }
       $0.subscriptionClient.unifiedStatusStream = { .finished }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
@@ -554,9 +544,7 @@ struct ProPlanFeatureTests {
     await store.receive(\.delegate.subscriptionStatusChanged)
     await store.finish()
 
-    // 클라이언트는 로컬 재검증을 수행하지 않아야 함
-    let localCalls = await localStatusCounter.value()
-    #expect(localCalls == 0)
+    // 클라이언트는 로컬 재검증을 수행하지 않으므로 서버 상태가 그대로 유지됨
     #expect(store.state.subscriptionStatus.isPro == true)
   }
 

--- a/Projects/Features/ProPlanFeature/Tests/Sources/ProPlanFeatureTests.swift
+++ b/Projects/Features/ProPlanFeature/Tests/Sources/ProPlanFeatureTests.swift
@@ -515,6 +515,51 @@ struct ProPlanFeatureTests {
     await store.finish()
   }
 
+  @Test("onAppear 시 서버 .subscribed + 만료일 과거여도 그대로 Pro 유지 (서버 SSOT)")
+  func onAppear_serverSubscribedExpiredDate_keepsPro() async {
+    let pastDate = Date().addingTimeInterval(-24 * 3600) // 1일 전
+    let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
+    actor CallCounter {
+      private var count = 0
+      func increment() { count += 1 }
+      func value() -> Int { count }
+    }
+    let localStatusCounter = CallCounter()
+
+    let store = makeStore {
+      $0.subscriptionClient.fetchStatus = { serverStatus }
+      $0.subscriptionClient.fetchLocalStatus = {
+        await localStatusCounter.increment()
+        return .none
+      }
+      $0.subscriptionClient.unifiedStatusStream = { .finished }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.view(.onAppear)) {
+      $0.isLoadingProducts = true
+    }
+
+    await store.receive(\.internal.productsResponse.success) {
+      $0.isLoadingProducts = false
+      $0.products = Self.mockProducts
+      $0.selectedProductId = SubscriptionProductType.yearly.productId
+    }
+
+    // 만료일이 과거여도 서버 .subscribed 응답이 그대로 dispatch 되어야 함
+    await store.receive(\.internal.statusUpdated) {
+      $0.subscriptionStatus = serverStatus
+    }
+
+    await store.receive(\.delegate.subscriptionStatusChanged)
+    await store.finish()
+
+    // 클라이언트는 로컬 재검증을 수행하지 않아야 함
+    let localCalls = await localStatusCounter.value()
+    #expect(localCalls == 0)
+    #expect(store.state.subscriptionStatus.isPro == true)
+  }
+
   @Test("onAppear 후 unifiedStatusStream revoked 수신 시 상태 갱신")
   func onAppear_unifiedStatusStreamRevoked_updatesStatus() async {
     let store = makeStore {

--- a/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
+++ b/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
@@ -750,29 +750,7 @@ extension RootTab {
           case .refreshSubscriptionStatus:
             return .run { [subscriptionClient] send in
               if let status = try? await subscriptionClient.fetchStatus() {
-                // 서버 상태가 subscribed인데 만료일이 지났으면 로컬 StoreKit으로 검증
-                // (AppStore.sync() 없이 — Apple ID 로그인 팝업 방지)
-                if case .subscribed(_, let expirationDate) = status,
-                   let expDate = expirationDate,
-                   expDate < Date() {
-                  do {
-                    let localStatus = try await subscriptionClient.fetchLocalStatus()
-                    if localStatus.isPro {
-                      // 로컬 StoreKit에서 활성 구독 확인됨 → 로컬 상태 우선 반영
-                      // (서버는 unifiedStatusStream으로 곧 동기화됨)
-                      await send(.internal(.subscriptionStatusChanged(localStatus)))
-                    } else {
-                      // 로컬에도 활성 구독 없음 → expired 처리
-                      await send(.internal(.subscriptionStatusChanged(.expired(expirationDate: expDate))))
-                    }
-                  } catch {
-                    // 로컬 조회 실패 시 서버 상태 그대로 사용
-                    AppLogger.subscription.error("[RootTab] Local status check failed: \(error)")
-                    await send(.internal(.subscriptionStatusChanged(status)))
-                  }
-                } else {
-                  await send(.internal(.subscriptionStatusChanged(status)))
-                }
+                await send(.internal(.subscriptionStatusChanged(status)))
               }
             }
 

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -661,14 +661,9 @@ struct RootTabFeatureTests {
   func refreshSubscription_notExpired_returnsServerStatus() async {
     let futureDate = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30) // 30일 후
     let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: futureDate)
-    let localStatusCounter = CallCounter()
 
     let store = makeStore(state: makeState(key: "refresh-not-expired")) {
       $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = {
-        await localStatusCounter.increment()
-        return .none
-      }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -679,23 +674,15 @@ struct RootTabFeatureTests {
       $0.settings.subscriptionStatus = serverStatus
     }
     await store.finish()
-
-    let localCalls = await localStatusCounter.value()
-    #expect(localCalls == 0)
   }
 
   @Test("서버 .subscribed + 만료일 과거여도 그대로 Pro 유지 (서버 SSOT)")
   func refreshSubscriptionStatus_serverSubscribedExpiredDate_keepsPro() async {
     let pastDate = Date(timeIntervalSinceNow: -60 * 60 * 24) // 1일 전
     let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
-    let localStatusCounter = CallCounter()
 
     let store = makeStore(state: makeState(key: "refresh-server-ssot-past-date")) {
       $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = {
-        await localStatusCounter.increment()
-        return .none
-      }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -707,9 +694,7 @@ struct RootTabFeatureTests {
     }
     await store.finish()
 
-    // 클라이언트는 만료일을 재판정하지 않으므로 fetchLocalStatus는 호출되지 않아야 함
-    let localCalls = await localStatusCounter.value()
-    #expect(localCalls == 0)
+    // 클라이언트는 만료일을 재판정하지 않으므로 서버 상태가 그대로 유지됨
     #expect(store.state.subscriptionStatus.isPro == true)
   }
 

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -651,15 +651,24 @@ struct RootTabFeatureTests {
     #expect(snapshot?.participants.first(where: { $0.id == "test-user" })?.estimatedArrivalMinutes == 12)
   }
 
-  // MARK: - refreshSubscriptionStatus 만료 감지 + 재검증 테스트
+  // MARK: - refreshSubscriptionStatus 서버 SSOT 정책 테스트
+  //
+  // 서버가 .subscribed / .lifetime / .gracePeriod로 응답하면 클라이언트는
+  // 만료일을 재판정하지 않고 서버 응답을 그대로 신뢰한다 (서버 SSOT).
+  // fetchLocalStatus는 더 이상 호출되지 않아야 한다.
 
   @Test("정상 구독 상태 (만료일 미래) - 서버 상태 그대로 반환")
   func refreshSubscription_notExpired_returnsServerStatus() async {
     let futureDate = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30) // 30일 후
     let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: futureDate)
+    let localStatusCounter = CallCounter()
 
     let store = makeStore(state: makeState(key: "refresh-not-expired")) {
       $0.subscriptionClient.fetchStatus = { serverStatus }
+      $0.subscriptionClient.fetchLocalStatus = {
+        await localStatusCounter.increment()
+        return .none
+      }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -669,58 +678,24 @@ struct RootTabFeatureTests {
       $0.subscriptionStatus = serverStatus
       $0.settings.subscriptionStatus = serverStatus
     }
+    await store.finish()
+
+    let localCalls = await localStatusCounter.value()
+    #expect(localCalls == 0)
   }
 
-  @Test("만료일 경과 + 로컬 StoreKit 활성 구독 확인 - 로컬 상태 우선 반영")
-  func refreshSubscription_expired_localStoreKitActive_usesLocalStatus() async {
-    let pastDate = Date(timeIntervalSinceNow: -60 * 60 * 24) // 1일 전
-    let newFutureDate = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30) // 30일 후
-    let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
-    let localStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: newFutureDate)
-
-    let store = makeStore(state: makeState(key: "refresh-expired-local-active")) {
-      $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = { localStatus }
-    }
-    store.exhaustivity = .off(showSkippedAssertions: false)
-
-    await store.send(.scenePhaseChanged(.active))
-    await store.receive(\.internal.refreshSubscriptionStatus)
-    await store.receive(\.internal.subscriptionStatusChanged) {
-      $0.subscriptionStatus = localStatus
-      $0.settings.subscriptionStatus = localStatus
-    }
-  }
-
-  @Test("만료일 경과 + 로컬 StoreKit 활성 구독 없음 - expired 처리")
-  func refreshSubscription_expired_noLocalActive_setsExpired() async {
+  @Test("서버 .subscribed + 만료일 과거여도 그대로 Pro 유지 (서버 SSOT)")
+  func refreshSubscriptionStatus_serverSubscribedExpiredDate_keepsPro() async {
     let pastDate = Date(timeIntervalSinceNow: -60 * 60 * 24) // 1일 전
     let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
+    let localStatusCounter = CallCounter()
 
-    let store = makeStore(state: makeState(key: "refresh-expired-no-local")) {
+    let store = makeStore(state: makeState(key: "refresh-server-ssot-past-date")) {
       $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = { .none }
-    }
-    store.exhaustivity = .off(showSkippedAssertions: false)
-
-    await store.send(.scenePhaseChanged(.active))
-    await store.receive(\.internal.refreshSubscriptionStatus)
-    await store.receive(\.internal.subscriptionStatusChanged) {
-      $0.subscriptionStatus = .expired(expirationDate: pastDate)
-      $0.settings.subscriptionStatus = .expired(expirationDate: pastDate)
-    }
-  }
-
-  @Test("만료일 경과 + 로컬 조회 실패 - 서버 상태 그대로 사용")
-  func refreshSubscription_expired_localFails_fallsBackToServerStatus() async {
-    let pastDate = Date(timeIntervalSinceNow: -60 * 60 * 24) // 1일 전
-    let serverStatus: SubscriptionStatus = .subscribed(productType: .monthly, expirationDate: pastDate)
-
-    struct MockError: Error {}
-
-    let store = makeStore(state: makeState(key: "refresh-expired-local-fail")) {
-      $0.subscriptionClient.fetchStatus = { serverStatus }
-      $0.subscriptionClient.fetchLocalStatus = { throw MockError() }
+      $0.subscriptionClient.fetchLocalStatus = {
+        await localStatusCounter.increment()
+        return .none
+      }
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
 
@@ -730,6 +705,12 @@ struct RootTabFeatureTests {
       $0.subscriptionStatus = serverStatus
       $0.settings.subscriptionStatus = serverStatus
     }
+    await store.finish()
+
+    // 클라이언트는 만료일을 재판정하지 않으므로 fetchLocalStatus는 호출되지 않아야 함
+    let localCalls = await localStatusCounter.value()
+    #expect(localCalls == 0)
+    #expect(store.state.subscriptionStatus.isPro == true)
   }
 
   @Test("lifetime 구독 - 재검증 없이 그대로 반환")

--- a/infra/rust-backend/src/services/subscription_service.rs
+++ b/infra/rust-backend/src/services/subscription_service.rs
@@ -37,8 +37,10 @@ pub async fn get_entitlement(
 ) -> Result<EntitlementResponse, AppError> {
     let record = fetch_entitlement_record(pool, user_id).await?;
     match record {
-        Some(record) => Ok(build_entitlement_response(&record)),
-        None => reconcile_entitlement(pool, user_id).await,
+        Some(record) if !is_entitlement_record_stale(&record) => {
+            Ok(build_entitlement_response(&record))
+        }
+        _ => reconcile_entitlement(pool, user_id).await,
     }
 }
 
@@ -629,10 +631,12 @@ async fn reconcile_entitlement_in_tx(
 ) -> Result<EntitlementResponse, AppError> {
     let subscription = fetch_subscription_record_in_tx(tx, user_id).await?;
     let entitlement_override = fetch_override_record_in_tx(tx, user_id).await?;
-    let subscription_status = subscription.as_ref().map(|record| record.status.clone());
-    let subscription_active = subscription_status
+    let subscription_status = subscription
         .as_ref()
-        .map(is_active_subscription_status)
+        .map(|record| effective_status(&record.status, record.expiration_date));
+    let subscription_active = subscription
+        .as_ref()
+        .map(|record| is_active_subscription_status(&record.status, record.expiration_date))
         .unwrap_or(false);
     let override_active = entitlement_override
         .as_ref()
@@ -714,7 +718,7 @@ async fn reconcile_entitlement_in_tx(
 fn build_status_response(record: Option<&SubscriptionRecord>) -> SubscriptionStatusResponse {
     match record {
         Some(record) => SubscriptionStatusResponse {
-            status: record.status.clone(),
+            status: effective_status(&record.status, record.expiration_date),
             product_id: record.product_id.clone(),
             original_transaction_id: record.original_transaction_id.clone(),
             expiration_date: record.expiration_date,
@@ -769,13 +773,63 @@ fn is_override_active(record: &EntitlementOverrideRecord) -> bool {
     }
 }
 
-fn is_active_subscription_status(status: &SubscriptionStatus) -> bool {
-    matches!(
-        status,
-        SubscriptionStatus::Subscribed
-            | SubscriptionStatus::Lifetime
-            | SubscriptionStatus::GracePeriod
-    )
+fn is_active_subscription_status(
+    status: &SubscriptionStatus,
+    expiration_date: Option<DateTime<Utc>>,
+) -> bool {
+    match status {
+        SubscriptionStatus::Lifetime => true,
+        SubscriptionStatus::Subscribed | SubscriptionStatus::GracePeriod => match expiration_date {
+            Some(date) => date > Utc::now(),
+            None => true,
+        },
+        _ => false,
+    }
+}
+
+fn effective_status(
+    status: &SubscriptionStatus,
+    expiration_date: Option<DateTime<Utc>>,
+) -> SubscriptionStatus {
+    match status {
+        SubscriptionStatus::Subscribed | SubscriptionStatus::GracePeriod => match expiration_date {
+            Some(date) if date <= Utc::now() => SubscriptionStatus::Expired,
+            _ => status.clone(),
+        },
+        _ => status.clone(),
+    }
+}
+
+fn is_entitlement_record_stale(record: &EntitlementRecord) -> bool {
+    if !record.has_pro {
+        return false;
+    }
+    let now = Utc::now();
+    match record.source {
+        EntitlementSource::Subscription => {
+            if matches!(
+                record.subscription_status,
+                Some(SubscriptionStatus::Lifetime)
+            ) {
+                return false;
+            }
+            if let Some(date) = record.expiration_date {
+                if date <= now {
+                    return true;
+                }
+            }
+            false
+        }
+        EntitlementSource::Override => {
+            if let Some(date) = record.override_expires_at {
+                if date <= now {
+                    return true;
+                }
+            }
+            false
+        }
+        EntitlementSource::None => false,
+    }
 }
 
 fn is_no_op_notification(notification_type: &AppStoreNotificationKind) -> bool {

--- a/infra/rust-backend/src/services/subscription_service.rs
+++ b/infra/rust-backend/src/services/subscription_service.rs
@@ -143,7 +143,7 @@ pub async fn verify_purchase(
     // 트랜잭션 커밋 후 Slack 알림 (메인 흐름 비차단)
     let before_status = current_record
         .as_ref()
-        .map(|r| r.status.as_str().to_string());
+        .map(|r| effective_status(&r.status, r.expiration_date).as_str().to_string());
     let after_status = subscription_response.status.as_str().to_string();
     let after_last_notification_type = subscription_response.last_notification_type.clone();
     let before_last_notification_type = current_record
@@ -274,7 +274,7 @@ pub async fn handle_apple_notification(
     let webhook_url = std::env::var("SLACK_WEBHOOK_URL").unwrap_or_default();
     let before_status = current_record
         .as_ref()
-        .map(|r| r.status.as_str().to_string());
+        .map(|r| effective_status(&r.status, r.expiration_date).as_str().to_string());
     let after_last_notification_type = Some(notification.notification_type.as_str().to_string());
     let before_last_notification_type = current_record
         .as_ref()
@@ -308,6 +308,10 @@ pub async fn reconcile_entitlement(
     user_id: &str,
 ) -> Result<EntitlementResponse, AppError> {
     let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
     let entitlement = reconcile_entitlement_in_tx(&mut tx, user_id).await?;
     tx.commit().await?;
     Ok(entitlement)
@@ -781,7 +785,7 @@ fn is_active_subscription_status(
         SubscriptionStatus::Lifetime => true,
         SubscriptionStatus::Subscribed | SubscriptionStatus::GracePeriod => match expiration_date {
             Some(date) => date > Utc::now(),
-            None => true,
+            None => false,
         },
         _ => false,
     }
@@ -813,12 +817,11 @@ fn is_entitlement_record_stale(record: &EntitlementRecord) -> bool {
             ) {
                 return false;
             }
-            if let Some(date) = record.expiration_date {
-                if date <= now {
-                    return true;
-                }
+            match record.expiration_date {
+                Some(date) if date <= now => true,
+                None => true,
+                _ => false,
             }
-            false
         }
         EntitlementSource::Override => {
             if let Some(date) = record.override_expires_at {

--- a/infra/rust-backend/tests/subscriptions_test.rs
+++ b/infra/rust-backend/tests/subscriptions_test.rs
@@ -452,3 +452,192 @@ async fn notify_slack_builds_correct_context_from_db(pool: PgPool) {
     // )
     // .await;
 }
+
+// === Subscription expiration regression tests (Red phase) ===
+//
+// 현재 `is_active_subscription_status`는 status enum 값만 보고 만료를 판정하지 않는다.
+// 또한 `get_entitlement`는 캐시된 entitlements row가 있으면 reconcile 없이 그대로 반환한다.
+// 아래 테스트들은 만료된 구독/캐시가 stale한 상황에서 has_pro=false 가 되어야 함을 명세한다.
+
+async fn insert_subscription_row(
+    pool: &PgPool,
+    user_id: &str,
+    status_db_value: &str,
+    expiration_date: Option<chrono::DateTime<Utc>>,
+) {
+    sqlx::query(
+        "INSERT INTO subscriptions
+            (user_id, status, product_id, original_transaction_id,
+             expiration_date, purchase_date, latest_app_store_signed_date,
+             latest_transaction_id)
+         VALUES
+            ($1, $2::subscription_status, $3, $4, $5, NOW() - INTERVAL '60 days', $6, $7)",
+    )
+    .bind(user_id)
+    .bind(status_db_value)
+    .bind("com.promiso.pro.monthly")
+    .bind(format!("otx_{user_id}"))
+    .bind(expiration_date)
+    .bind(Utc::now().timestamp_millis())
+    .bind(format!("tx_{user_id}"))
+    .execute(pool)
+    .await
+    .expect("Failed to insert subscription row");
+}
+
+async fn insert_entitlement_row(
+    pool: &PgPool,
+    user_id: &str,
+    has_pro: bool,
+    subscription_status_db: Option<&str>,
+    expiration_date: Option<chrono::DateTime<Utc>>,
+    source: &str,
+    override_active: bool,
+    override_expires_at: Option<chrono::DateTime<Utc>>,
+) {
+    sqlx::query(
+        "INSERT INTO entitlements
+            (user_id, has_pro, source, subscription_status, product_id,
+             expiration_date, override_active, override_expires_at)
+         VALUES
+            ($1, $2, $3::entitlement_source,
+             $4::subscription_status, $5, $6, $7, $8)",
+    )
+    .bind(user_id)
+    .bind(has_pro)
+    .bind(source)
+    .bind(subscription_status_db)
+    .bind("com.promiso.pro.monthly")
+    .bind(expiration_date)
+    .bind(override_active)
+    .bind(override_expires_at)
+    .execute(pool)
+    .await
+    .expect("Failed to insert entitlement row");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_entitlement_returns_expired_when_subscription_expiration_in_past(pool: PgPool) {
+    let past = Utc::now() - Duration::days(120);
+    insert_subscription_row(&pool, "expired_sub_user", "subscribed", Some(past)).await;
+
+    let entitlement = subscription_service::get_entitlement(&pool, "expired_sub_user")
+        .await
+        .expect("entitlement should reconcile");
+
+    assert!(
+        !entitlement.has_pro,
+        "만료된 subscription은 has_pro=false 여야 한다"
+    );
+    assert_ne!(
+        entitlement.subscription_status,
+        Some(SubscriptionStatus::Subscribed),
+        "만료된 subscription의 effective status는 Subscribed가 아니어야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_entitlement_returns_expired_when_grace_period_expired(pool: PgPool) {
+    let past = Utc::now() - Duration::days(10);
+    insert_subscription_row(&pool, "expired_grace_user", "grace_period", Some(past)).await;
+
+    let entitlement = subscription_service::get_entitlement(&pool, "expired_grace_user")
+        .await
+        .expect("entitlement should reconcile");
+
+    assert!(
+        !entitlement.has_pro,
+        "유예기간이 지난 subscription은 has_pro=false 여야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_entitlement_recomputes_when_cached_row_is_stale(pool: PgPool) {
+    let past = Utc::now() - Duration::days(30);
+    // subscriptions: 만료된 'subscribed'
+    insert_subscription_row(&pool, "stale_cache_user", "subscribed", Some(past)).await;
+    // entitlements: stale 캐시 (has_pro=true 로 잘못 저장됨)
+    insert_entitlement_row(
+        &pool,
+        "stale_cache_user",
+        true,
+        Some("subscribed"),
+        Some(past),
+        "subscription",
+        false,
+        None,
+    )
+    .await;
+
+    let entitlement = subscription_service::get_entitlement(&pool, "stale_cache_user")
+        .await
+        .expect("entitlement should be returned");
+
+    assert!(
+        !entitlement.has_pro,
+        "캐시된 entitlements가 stale하면 reconcile해서 has_pro=false 여야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_entitlement_returns_expired_when_override_expires_at_in_past(pool: PgPool) {
+    let past = Utc::now() - Duration::days(2);
+    // 만료된 override
+    insert_override(&pool, "expired_override_user", true, "manual_pro_grant", Some(past)).await;
+    // stale 캐시: has_pro=true 인 채로 저장되어 있음
+    insert_entitlement_row(
+        &pool,
+        "expired_override_user",
+        true,
+        None,
+        None,
+        "override",
+        true,
+        Some(past),
+    )
+    .await;
+
+    let entitlement = subscription_service::get_entitlement(&pool, "expired_override_user")
+        .await
+        .expect("entitlement should be returned");
+
+    assert!(
+        !entitlement.has_pro,
+        "만료된 override는 캐시가 stale 하더라도 has_pro=false 여야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_endpoint_maps_expired_subscribed_to_expired(pool: PgPool) {
+    let past = Utc::now() - Duration::days(45);
+    insert_subscription_row(&pool, "status_expired_user", "subscribed", Some(past)).await;
+
+    let status = subscription_service::get_status(&pool, "status_expired_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Expired,
+        "만료일이 과거인 subscribed 레코드는 effective status=Expired 로 응답해야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_lifetime_status_remains_active_regardless_of_expiration(pool: PgPool) {
+    // Lifetime: expiration_date=NULL 이어도 항상 활성 (회귀 방지)
+    insert_subscription_row(&pool, "lifetime_user", "lifetime", None).await;
+
+    let entitlement = subscription_service::get_entitlement(&pool, "lifetime_user")
+        .await
+        .expect("entitlement should reconcile");
+
+    assert!(
+        entitlement.has_pro,
+        "Lifetime은 만료 검사 대상이 아니므로 항상 has_pro=true 여야 한다"
+    );
+    assert_eq!(
+        entitlement.subscription_status,
+        Some(SubscriptionStatus::Lifetime)
+    );
+}


### PR DESCRIPTION
## 문제

만료된 구독 유저가 앱에서 **"처음 미구독 → 갑자기 구독중"** 으로 플리커되는 버그.

### 원인 (서버 + 클라이언트 양쪽)

**서버 측 (근본 원인)**: `subscription_service::is_active_subscription_status`가 status enum만 보고 활성 여부 판단. `expiration_date`를 검사하지 않아, DB에 `status='subscribed'` + `expiration_date=과거`인 stale 레코드가 있으면 `/api/v1/subscriptions/entitlement`가 `hasPro=true`로 응답. Apple S2S 알림 누락/지연 시 stale 상태가 그대로 노출됨.

**클라이언트 측**: 서버 응답을 다시 의심해서 `expirationDate <= Date()`로 재판정하는 경로가 4곳에 있었음. 사용자 정책("서버 정보가 단일 중심, 애플에서 만료됐다 해도 서버 정보로 유지")과 반대.

## 해결

**서버를 단일 진실 공급원(SSOT)으로 정렬.** 서버가 정확한 만료 판정을 하고, 클라이언트는 그대로 신뢰.

### Rust 백엔드 (`subscription_service.rs`)
- `is_active_subscription_status`에 `expiration_date` 인자 추가. `Subscribed`/`GracePeriod`는 만료일이 미래일 때만 active. `Lifetime`은 만료 검사 제외.
- `effective_status` (신규): 만료된 `Subscribed`/`GracePeriod`를 `Expired`로 응답 시점 매핑.
- `is_entitlement_record_stale` (신규): 캐시된 entitlement의 `expiration_date`/`override_expires_at` 검사.
- `get_entitlement`: stale 캐시면 reconcile 호출.
- `build_status_response`: effective_status 적용.

### iOS 클라이언트
- `RootTabFeature.refreshSubscriptionStatus`: 로컬 StoreKit 재판정 분기 제거. 서버 응답 그대로 dispatch.
- (working tree에 추가되어 있던 SubscriptionRustDataSource mapEntitlement / Subscription.isActive / ProPlanFeature 콜드스타트 재판정도 모두 revert하여 main과 동일하게 유지)

## 테스트

| 모듈 | 결과 |
|---|---|
| `cargo test --test subscriptions_test` | ✅ 14/14 PASS (5 신규 SSOT + 1 회귀 방지 + 8 기존) |
| `make test-module MODULE=RootTabFeature` | ✅ 83/83 PASS |
| `make test-module MODULE=ProPlanFeature` | ✅ 27/27 PASS |
| `make test-module MODULE=Clients` | ✅ 315/315 PASS |

신규 테스트:
- Rust: `test_entitlement_returns_expired_when_subscription_expiration_in_past`, `test_entitlement_returns_expired_when_grace_period_expired`, `test_entitlement_recomputes_when_cached_row_is_stale`, `test_entitlement_returns_expired_when_override_expires_at_in_past`, `test_status_endpoint_maps_expired_subscribed_to_expired`, `test_lifetime_status_remains_active_regardless_of_expiration`
- iOS: RootTab `"서버 .subscribed + 만료일 과거여도 그대로 Pro 유지 (서버 SSOT)"`, ProPlan `"onAPpear 시 서버 .subscribed + 만료일 과거여도 그대로 Pro 유지 (서버 SSOT)"`

## 배포 순서 (중요)

**Rust 서버 먼저 배포 → iOS 빌드는 별도 출시.**

iOS만 먼저 출시되면 사용자는 새 클라이언트(서버 SSOT)를 받지만 서버는 stale `hasPro=true`를 계속 응답 → 만료 유저가 계속 Pro로 보이는 부작용. Rust를 먼저 배포하면 기존 클라이언트(재판정 로직)에서도 자연스럽게 정상 동작.

## 영향 범위 확인 필요 (배포 전)

prod Neon에서 다음 쿼리로 영향 받는 유저 수 확인 필요:

\`\`\`sql
-- 만료된 활성 subscription
SELECT COUNT(*) FROM subscriptions
WHERE status IN ('subscribed', 'gracePeriod') AND expiration_date <= NOW();

-- 만료된 활성 entitlement override
SELECT COUNT(*) FROM entitlement_overrides
WHERE is_active = true AND expires_at <= NOW();

-- 즉시 hasPro=false로 전환될 유저 수
SELECT COUNT(*) FROM entitlements
WHERE has_pro = true
  AND ((source = 'subscription' AND expiration_date <= NOW())
    OR (source = 'override' AND override_expires_at <= NOW()));
\`\`\`

## Test plan

- [x] Rust subscription 테스트 14/14 PASS
- [x] iOS RootTab/ProPlan/Clients 테스트 모두 PASS
- [ ] prod DB 영향 범위 쿼리 실행 (배포 전)
- [ ] Rust 서버 배포 후 Cloud Run 헬스 체크
- [ ] Rust 서버 배포 후 만료 유저 entitlement reconcile 동작 확인
- [ ] iOS TestFlight 빌드로 만료 유저 케이스 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)