### PR TITLE
fix: /subscriptions/status에 entitlement_overrides 통합 (핫픽스)

### DIFF
--- a/infra/rust-backend/src/services/subscription_service.rs
+++ b/infra/rust-backend/src/services/subscription_service.rs
@@ -27,8 +27,34 @@ pub async fn get_status(
     pool: &PgPool,
     user_id: &str,
 ) -> Result<SubscriptionStatusResponse, AppError> {
-    let record = fetch_subscription_record(pool, user_id).await?;
-    Ok(build_status_response(record.as_ref()))
+    let subscription = fetch_subscription_record(pool, user_id).await?;
+    let entitlement_override = fetch_override_record(pool, user_id).await?;
+
+    let subscription_active = subscription
+        .as_ref()
+        .map(|record| is_active_subscription_status(&record.status, record.expiration_date))
+        .unwrap_or(false);
+    let override_active = entitlement_override
+        .as_ref()
+        .map(is_override_active)
+        .unwrap_or(false);
+
+    let base_response = build_status_response(subscription.as_ref());
+
+    // subscription이 활성이거나 override도 비활성이면 subscriptions 기반 응답을 그대로 반환
+    if subscription_active || !override_active {
+        return Ok(base_response);
+    }
+
+    // subscription 비활성 + override 활성 → override 기준으로 Subscribed 응답
+    let override_expires_at = entitlement_override
+        .as_ref()
+        .and_then(|record| record.expires_at);
+    Ok(SubscriptionStatusResponse {
+        status: SubscriptionStatus::Subscribed,
+        expiration_date: override_expires_at,
+        ..base_response
+    })
 }
 
 pub async fn get_entitlement(
@@ -545,6 +571,19 @@ async fn fetch_override_record_in_tx(
     )
     .bind(user_id)
     .fetch_optional(&mut **tx)
+    .await
+    .map_err(AppError::from)
+}
+
+async fn fetch_override_record(
+    pool: &PgPool,
+    user_id: &str,
+) -> Result<Option<EntitlementOverrideRecord>, AppError> {
+    sqlx::query_as::<_, EntitlementOverrideRecord>(
+        "SELECT * FROM entitlement_overrides WHERE user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_optional(pool)
     .await
     .map_err(AppError::from)
 }

--- a/infra/rust-backend/tests/subscriptions_test.rs
+++ b/infra/rust-backend/tests/subscriptions_test.rs
@@ -641,3 +641,176 @@ async fn test_lifetime_status_remains_active_regardless_of_expiration(pool: PgPo
         Some(SubscriptionStatus::Lifetime)
     );
 }
+
+// === GET /status override fallback regression tests ===
+//
+// `get_status`는 subscriptions 테이블만 보고 entitlement_overrides를 무시했다.
+// override만 활성인 유저는 status=Subscribed 로 응답해야 한다.
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_returns_subscribed_when_only_override_active(pool: PgPool) {
+    let future = Utc::now() + Duration::days(30);
+    insert_override(
+        &pool,
+        "status_override_only_user",
+        true,
+        "manual_pro_grant",
+        Some(future),
+    )
+    .await;
+
+    let status = subscription_service::get_status(&pool, "status_override_only_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Subscribed,
+        "active override만 있어도 status=Subscribed 여야 한다"
+    );
+    let returned_expiration = status
+        .expiration_date
+        .expect("override expires_at should be returned");
+    let diff = (returned_expiration - future).num_seconds().abs();
+    assert!(
+        diff < 2,
+        "expiration_date는 override의 expires_at과 일치해야 한다 (diff={diff}s)"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_returns_subscribed_when_subscription_expired_but_override_active(
+    pool: PgPool,
+) {
+    let past = Utc::now() - Duration::days(10);
+    let future = Utc::now() + Duration::days(15);
+    insert_subscription_row(
+        &pool,
+        "status_expired_with_override_user",
+        "subscribed",
+        Some(past),
+    )
+    .await;
+    insert_override(
+        &pool,
+        "status_expired_with_override_user",
+        true,
+        "manual_pro_grant",
+        Some(future),
+    )
+    .await;
+
+    let status = subscription_service::get_status(&pool, "status_expired_with_override_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Subscribed,
+        "subscription이 만료여도 override가 활성이면 status=Subscribed 여야 한다"
+    );
+    let returned_expiration = status
+        .expiration_date
+        .expect("override expires_at should be returned");
+    let diff = (returned_expiration - future).num_seconds().abs();
+    assert!(
+        diff < 2,
+        "expiration_date는 override의 expires_at과 일치해야 한다 (diff={diff}s)"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_returns_expired_when_subscription_expired_and_override_inactive(
+    pool: PgPool,
+) {
+    let past = Utc::now() - Duration::days(20);
+    insert_subscription_row(
+        &pool,
+        "status_both_inactive_user",
+        "subscribed",
+        Some(past),
+    )
+    .await;
+    // override는 is_active=false
+    insert_override(
+        &pool,
+        "status_both_inactive_user",
+        false,
+        "manual_pro_grant",
+        Some(Utc::now() + Duration::days(30)),
+    )
+    .await;
+
+    let status = subscription_service::get_status(&pool, "status_both_inactive_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Expired,
+        "subscription 만료 + override 비활성이면 status=Expired 여야 한다"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_returns_subscribed_when_subscription_active_overrides_irrelevant(
+    pool: PgPool,
+) {
+    let future_sub = Utc::now() + Duration::days(45);
+    insert_subscription_row(
+        &pool,
+        "status_sub_active_user",
+        "subscribed",
+        Some(future_sub),
+    )
+    .await;
+    insert_override(
+        &pool,
+        "status_sub_active_user",
+        false,
+        "manual_pro_grant",
+        Some(Utc::now() + Duration::days(7)),
+    )
+    .await;
+
+    let status = subscription_service::get_status(&pool, "status_sub_active_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Subscribed,
+        "subscription이 활성이면 override 비활성과 무관하게 status=Subscribed 여야 한다"
+    );
+    let returned_expiration = status
+        .expiration_date
+        .expect("subscription expiration should be returned");
+    let diff = (returned_expiration - future_sub).num_seconds().abs();
+    assert!(
+        diff < 2,
+        "expiration_date는 subscription의 expiration_date와 일치해야 한다 (diff={diff}s)"
+    );
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn test_status_returns_lifetime_regardless_of_override(pool: PgPool) {
+    insert_subscription_row(&pool, "status_lifetime_user", "lifetime", None).await;
+    insert_override(
+        &pool,
+        "status_lifetime_user",
+        true,
+        "manual_pro_grant",
+        Some(Utc::now() + Duration::days(7)),
+    )
+    .await;
+
+    let status = subscription_service::get_status(&pool, "status_lifetime_user")
+        .await
+        .expect("status should return");
+
+    assert_eq!(
+        status.status,
+        SubscriptionStatus::Lifetime,
+        "Lifetime subscription은 override와 무관하게 Lifetime을 유지해야 한다"
+    );
+}


### PR DESCRIPTION
## 문제

PR #309 후속 핫픽스. \`/api/v1/subscriptions/status\` 엔드포인트가 \`subscriptions\` 테이블만 보고 \`entitlement_overrides\`는 무시하여, **override만 활성인 유저에게 \`status="expired"\` 응답**.

### 증상
admin grant / 쿠폰 redeem 받은 유저가 앱에서 ProPlanManageView ↔ PaywallView **깜빡임**:
- \`fetchStatus()\` (= /status) → effective Expired → \`.expired\` → PaywallView
- \`fetchEntitlementStatus()\` (= /entitlement) → hasPro=true, source=override → \`.subscribed\` → ProPlanManageView

두 엔드포인트가 같은 유저에 대해 다른 답을 줘서 클라이언트가 두 화면 사이를 오갑니다.

## 해결

\`get_status\`가 subscription + override를 둘 다 fetch하여 통합 결정:
- subscription이 effective active → 그대로 응답
- subscription 비활성 + override 활성 → \`status=Subscribed\`, \`expiration_date=override.expires_at\` 응답
- 둘 다 없음 → 기존 동작 (none)

## 호환성

**iOS 앱 변경 불필요**. 기존 v1.4.0 클라이언트도 mapStatus는 \`status="subscribed"\` + \`expiration_date\`만 디코딩하므로 자동 정상화.

## 테스트

\`cargo test --test subscriptions_test\`: **19/19 PASS** (5 신규 + 14 기존)

신규 테스트:
- \`test_status_returns_subscribed_when_only_override_active\`
- \`test_status_returns_subscribed_when_subscription_expired_but_override_active\`
- \`test_status_returns_expired_when_subscription_expired_and_override_inactive\`
- \`test_status_returns_subscribed_when_subscription_active_overrides_irrelevant\`
- \`test_status_returns_lifetime_regardless_of_override\`

## 배포

dev → stage → prod 순서로 모두 배포 예정.

## Test plan

- [x] cargo test 통과
- [ ] dev 배포 후 헬스 체크
- [ ] stage 배포 후 헬스 체크
- [ ] prod 배포 후 성원/재윤 유저 entitlement 응답 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)