### PR TITLE
fix: prod 지도검색 헤더 오류 수정

### DIFF
--- a/infra/rust-backend/.dockerignore
+++ b/infra/rust-backend/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.env
+.env.*
+.git/
+.DS_Store

--- a/infra/rust-backend/.gcloudignore
+++ b/infra/rust-backend/.gcloudignore
@@ -1,0 +1,5 @@
+target/
+.env
+.env.*
+.git/
+.DS_Store

--- a/infra/rust-backend/src/services/places_service.rs
+++ b/infra/rust-backend/src/services/places_service.rs
@@ -32,9 +32,10 @@ pub async fn search_places(
         .build()
         .map_err(|e| AppError::Internal(format!("Failed to build HTTP client: {e}")))?;
 
+    let authorization = kakao_authorization_header_value(api_key);
     let resp = client
         .get("https://dapi.kakao.com/v2/local/search/keyword.json")
-        .header("Authorization", format!("KakaoAK {api_key}"))
+        .header("Authorization", authorization)
         .query(&[("query", query), ("size", &size.to_string())])
         .send()
         .await
@@ -53,6 +54,10 @@ pub async fn search_places(
         .map_err(|e| AppError::Internal(format!("Kakao Places response parse failed: {e}")))?;
 
     Ok(parse_kakao_places_response(&json))
+}
+
+pub fn kakao_authorization_header_value(api_key: &str) -> String {
+    format!("KakaoAK {}", api_key.trim())
 }
 
 /// Kakao 키워드 검색 응답 JSON에서 장소 목록을 파싱한다.

--- a/infra/rust-backend/src/services/places_service.rs
+++ b/infra/rust-backend/src/services/places_service.rs
@@ -1,3 +1,4 @@
+use reqwest::header::AUTHORIZATION;
 use reqwest::Client;
 
 use crate::errors::AppError;
@@ -32,10 +33,10 @@ pub async fn search_places(
         .build()
         .map_err(|e| AppError::Internal(format!("Failed to build HTTP client: {e}")))?;
 
-    let authorization = kakao_authorization_header_value(api_key);
+    let authorization = kakao_authorization_header(api_key)?;
     let resp = client
         .get("https://dapi.kakao.com/v2/local/search/keyword.json")
-        .header("Authorization", authorization)
+        .header(AUTHORIZATION, authorization)
         .query(&[("query", query), ("size", &size.to_string())])
         .send()
         .await
@@ -58,6 +59,14 @@ pub async fn search_places(
 
 pub fn kakao_authorization_header_value(api_key: &str) -> String {
     format!("KakaoAK {}", api_key.trim())
+}
+
+pub fn kakao_authorization_header(api_key: &str) -> Result<reqwest::header::HeaderValue, AppError> {
+    let mut header =
+        reqwest::header::HeaderValue::from_str(&kakao_authorization_header_value(api_key))
+            .map_err(|e| AppError::Internal(format!("Invalid Kakao authorization header: {e}")))?;
+    header.set_sensitive(true);
+    Ok(header)
 }
 
 /// Kakao 키워드 검색 응답 JSON에서 장소 목록을 파싱한다.

--- a/infra/rust-backend/tests/external_api_test.rs
+++ b/infra/rust-backend/tests/external_api_test.rs
@@ -2,7 +2,9 @@
 //!
 //! 실제 HTTP 호출 없이 알려진 JSON 응답을 파싱하는 순수 함수를 테스트한다.
 
-use promiso_backend::services::{gemini_client, transportation_client, weather_client};
+use promiso_backend::services::{
+    gemini_client, places_service, transportation_client, weather_client,
+};
 use serde_json::json;
 
 // ============================================================
@@ -256,6 +258,13 @@ fn parse_odsay_handles_empty_result() {
 // ============================================================
 // Kakao Mobility 파싱 테스트
 // ============================================================
+
+/// Secret Manager 값에 trailing newline이 있어도 Authorization 헤더는 유효해야 한다.
+#[test]
+fn kakao_authorization_header_trims_secret_whitespace() {
+    let header = places_service::kakao_authorization_header_value("  rest-api-key\n");
+    assert_eq!(header, "KakaoAK rest-api-key");
+}
 
 /// duration(초→분), distance(m→km), toll 추출
 #[test]

--- a/infra/rust-backend/tests/external_api_test.rs
+++ b/infra/rust-backend/tests/external_api_test.rs
@@ -262,8 +262,12 @@ fn parse_odsay_handles_empty_result() {
 /// Secret Manager 값에 trailing newline이 있어도 Authorization 헤더는 유효해야 한다.
 #[test]
 fn kakao_authorization_header_trims_secret_whitespace() {
-    let header = places_service::kakao_authorization_header_value("  rest-api-key\n");
-    assert_eq!(header, "KakaoAK rest-api-key");
+    let header = places_service::kakao_authorization_header("  rest-api-key\n").unwrap();
+    assert_eq!(header.to_str().unwrap(), "KakaoAK rest-api-key");
+    assert!(
+        header.is_sensitive(),
+        "Authorization header should be sensitive"
+    );
 }
 
 /// duration(초→분), distance(m→km), toll 추출


### PR DESCRIPTION
## 요약
- Kakao Places API Authorization 헤더 생성 시 `KAKAO_REST_API_KEY`를 `trim()` 처리
- Secret Manager 값에 trailing whitespace/newline이 포함되어도 prod 지도검색 요청이 `builder error`로 실패하지 않도록 방어
- Cloud Run/Cloud Build 배포 컨텍스트에서 `target/`, 로컬 env 파일을 제외하도록 `.dockerignore`, `.gcloudignore` 추가

## 원인
- prod `/api/v1/places/search`가 500을 반환했고 Cloud Run 로그에 `Kakao Places API request failed: builder error`가 기록됨
- Secret 값의 공백/개행이 `Authorization: KakaoAK ...` 헤더 값에 그대로 들어가 reqwest header builder 단계에서 실패하는 케이스로 확인

## 검증
- Red: `kakao_authorization_header_trims_secret_whitespace` 실패 확인
- Green: 동일 테스트 통과
- `cargo test --manifest-path infra/rust-backend/Cargo.toml --test external_api_test` 통과 (13 passed)
- prod Cloud Build 성공: `717e54fb-3253-47f5-bb0b-6874a4312a65`
- prod Cloud Run 배포 완료: `promiso-api-00014-cdd`, traffic 100%
- prod smoke:
  - `/health` → 200
  - `/api/v1/places/search?q=강남역&size=3` → 200, 장소 결과 정상 반환
  - 새 revision ERROR 로그 없음
