### PR TITLE
fix: 초기 그룹 일정 로드 보강

### DIFF
--- a/Projects/Clients/Sources/Domain/Models/UserModel.swift
+++ b/Projects/Clients/Sources/Domain/Models/UserModel.swift
@@ -169,7 +169,7 @@ public struct UserPrivateModel: UserPrivateInfo, Identifiable, Equatable, Hashab
   public let email: String
   public let provider: String
   /// 사용자가 속한 그룹 목록
-  public let groups: [UserGroupInfo]
+  public var groups: [UserGroupInfo]
 
   public var id: String { userId }
 

--- a/Projects/Features/HomeFeature/Sources/HomeFeature.swift
+++ b/Projects/Features/HomeFeature/Sources/HomeFeature.swift
@@ -246,6 +246,8 @@ extension Home {
         case onAppear
         /// Pull to refresh
         case refreshTriggered
+        /// 그룹 멤버십 갱신으로 그룹 일정만 다시 조회
+        case groupMembershipChanged
         /// 오늘 일정 일정 카드 탭
         case todayScheduleTapped(ScheduleModel)
         /// 응답 필요 일정 카드 탭 (그룹 탭으로 이동)
@@ -463,6 +465,9 @@ extension Home {
               .send(.internal(.fetchPersonalEvents)),
               .send(.internal(.fetchRecurringEvents))
             )
+
+          case .groupMembershipChanged:
+            return .send(.internal(.fetchSchedules))
 
           case .todayScheduleTapped(let schedule):
             // 즉시 이동 (캐시 hit면 전달, miss면 nil로 전달 → Detail에서 로드)

--- a/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
+++ b/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
@@ -109,6 +109,7 @@ extension RootTab {
     @Dependency(\.authClient) var authClient
     @Dependency(\.notificationClient) var notificationClient
     @Dependency(\.scheduleClient) var scheduleClient
+    @Dependency(\.groupClient) var groupClient
     @Dependency(\.calendarSyncClient) var calendarSyncClient
     @Dependency(\.analyticsClient) var analyticsClient
     @Dependency(\.subscriptionClient) var subscriptionClient
@@ -135,6 +136,9 @@ extension RootTab {
 
       /// 캘린더 동기화 실행 중 상태
       var isCalendarSyncInFlight: Bool = false
+
+      /// 진행 중인 캘린더 동기화 완료 후 재동기화가 필요한지 추적
+      var isCalendarSyncRetryPending: Bool = false
 
       /// Home Main State
       var home: Home.Feature.State
@@ -271,6 +275,8 @@ extension RootTab {
       case openETASheetAfterDelay
       /// 캘린더 동기화 (백그라운드)
       case syncCalendar
+      /// 진행 중인 캘린더 동기화가 있으면 완료 후 1회 재동기화
+      case syncCalendarAfterCurrent
       /// 구독 상태 모니터링 시작 (StoreKit + Firestore 통합)
       case observeSubscriptionStatus
       /// 구독 상태 변경 수신
@@ -279,6 +285,10 @@ extension RootTab {
       case refreshSubscriptionStatus
       /// 캘린더 동기화 완료 처리
       case syncCalendarFinished(success: Bool)
+      /// 서버 기준 그룹 요약 갱신
+      case refreshGroupSummaries
+      /// 서버 기준 그룹 요약 갱신 결과
+      case groupSummariesResponse(Result<[UserGroupInfo], AppError>)
       /// 서버 세션 만료 감지 (refresh token 실패)
       case sessionExpired
     }
@@ -320,6 +330,7 @@ extension RootTab {
             .send(.internal(.observePushToStartToken)),
             .send(.internal(.observeActivityUpdates)),
             .send(.internal(.observeVoteActivityUpdates)),
+            .send(.internal(.refreshGroupSummaries)),
             .send(.internal(.syncCalendar)),
             .send(.internal(.observeSubscriptionStatus)),
             .run { send in
@@ -723,11 +734,69 @@ extension RootTab {
               await send(.internal(.syncCalendarFinished(success: allSucceeded)))
             }
 
+          case .syncCalendarAfterCurrent:
+            guard !state.isCalendarSyncInFlight else {
+              state.isCalendarSyncRetryPending = true
+              return .none
+            }
+            return .send(.internal(.syncCalendar))
+
           case .syncCalendarFinished(let success):
             state.isCalendarSyncInFlight = false
             if success {
               state.hasInitialCalendarSyncBeenScheduled = true
             }
+            guard state.isCalendarSyncRetryPending else {
+              return .none
+            }
+            state.isCalendarSyncRetryPending = false
+            return .send(.internal(.syncCalendar))
+
+          case .refreshGroupSummaries:
+            return .run { [groupClient] send in
+              do {
+                let summaries = try await groupClient.fetchGroupSummaries()
+                await send(.internal(.groupSummariesResponse(.success(summaries))))
+              } catch {
+                await send(.internal(.groupSummariesResponse(.failure(AppError(error)))))
+              }
+            }
+
+          case .groupSummariesResponse(.success(let groupSummaries)):
+            let previousGroups = state.currentUser.groups
+            let normalizedGroups = Self.normalizedGroups(groupSummaries)
+            state.$currentUser.withLock { user in
+              user = UserPrivateModel(
+                userId: user.userId,
+                name: user.name,
+                nickname: user.nickname,
+                email: user.email,
+                provider: user.provider,
+                profile: user.profile,
+                metadata: user.metadata,
+                groups: normalizedGroups
+              )
+            }
+            state.groupMain.allGroupSummaries = normalizedGroups
+
+            analyticsClient.setGroupMembershipProperties(normalizedGroups)
+            analyticsClient.setCalendarSyncEnabled(
+              personalEnabled: userDefaultsClient.boolForKey(AppConstants.UserDefaults.personalCalendarSync),
+              groups: normalizedGroups
+            )
+
+            guard normalizedGroups != previousGroups else {
+              return .none
+            }
+
+            let effects: [Effect<Action>] = [
+              .send(.home(.internal(.fetchSchedules))),
+              .send(.calendar(.view(.refresh))),
+              .send(.internal(.syncCalendarAfterCurrent))
+            ]
+            return .merge(effects)
+
+          case .groupSummariesResponse(.failure):
             return .none
 
           case .sessionExpired:
@@ -784,6 +853,16 @@ extension RootTab {
       $isPro.withLock { $0 = status.isPro }
       analyticsClient.setSubscriptionTier(status)
       return .none
+    }
+
+    private static func normalizedGroups(_ groups: [UserGroupInfo]) -> [UserGroupInfo] {
+      var latestGroupsById: [String: UserGroupInfo] = [:]
+      for group in groups {
+        latestGroupsById[group.id] = group
+      }
+      return latestGroupsById.values.sorted {
+        ($0.joinedAt ?? .distantPast) > ($1.joinedAt ?? .distantPast)
+      }
     }
   }
 }

--- a/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
+++ b/Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
@@ -766,16 +766,7 @@ extension RootTab {
             let previousGroups = state.currentUser.groups
             let normalizedGroups = Self.normalizedGroups(groupSummaries)
             state.$currentUser.withLock { user in
-              user = UserPrivateModel(
-                userId: user.userId,
-                name: user.name,
-                nickname: user.nickname,
-                email: user.email,
-                provider: user.provider,
-                profile: user.profile,
-                metadata: user.metadata,
-                groups: normalizedGroups
-              )
+              user.groups = normalizedGroups
             }
             state.groupMain.allGroupSummaries = normalizedGroups
 
@@ -790,7 +781,7 @@ extension RootTab {
             }
 
             let effects: [Effect<Action>] = [
-              .send(.home(.internal(.fetchSchedules))),
+              .send(.home(.view(.groupMembershipChanged))),
               .send(.calendar(.view(.refresh))),
               .send(.internal(.syncCalendarAfterCurrent))
             ]

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -110,6 +110,97 @@ struct RootTabFeatureTests {
     #expect(await syncCounter.value() == 2)
   }
 
+  @Test("그룹 요약 갱신 시 공유 유저 그룹을 갱신하고 홈/캘린더를 새로고침")
+  func groupSummariesResponse_updatesSharedGroupsAndRefreshesSchedules() async {
+    let group = makeGroupInfo(
+      id: "group-1",
+      name: "새 그룹",
+      notifications: GroupNotificationSettings(calendarSync: true)
+    )
+    let homeRecorder = GroupIdsArrayRecorder()
+    let syncRecorder = GroupIdsRecorder()
+
+    let store = makeStore(state: makeState(key: "group-summaries-refresh")) {
+      $0.scheduleClient.getHomeSchedules = { groupIds, _ in
+        await homeRecorder.record(groupIds)
+        return []
+      }
+      $0.calendarSyncClient.sync = { ids in
+        await syncRecorder.record(ids)
+        return CalendarSyncResult()
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.internal(.groupSummariesResponse(.success([group])))) {
+      $0.groupMain.allGroupSummaries = [group]
+    }
+    #expect(store.state.currentUser.groups == [group])
+
+    await store.receive(\.home.internal.fetchSchedules)
+    await store.receive(\.calendar.view.refresh)
+    await store.receive(\.internal.syncCalendarAfterCurrent)
+    await store.receive(\.internal.syncCalendar) {
+      $0.isCalendarSyncInFlight = true
+    }
+    await store.receive(\.home.internal.schedulesResponse.success)
+    await store.receive(\.internal.syncCalendarFinished) {
+      $0.isCalendarSyncInFlight = false
+      $0.hasInitialCalendarSyncBeenScheduled = true
+    }
+    await store.finish()
+
+    #expect(await homeRecorder.value() == [["group-1"]])
+    #expect(await syncRecorder.value() == Set(["group-1"]))
+  }
+
+  @Test("그룹 요약 갱신 중 캘린더 동기화가 진행 중이면 완료 후 재동기화")
+  func groupSummariesResponse_queuesCalendarSyncRetryWhenInFlight() async {
+    let group = makeGroupInfo(
+      id: "group-1",
+      name: "새 그룹",
+      notifications: GroupNotificationSettings(calendarSync: true)
+    )
+    let syncRecorder = GroupIdsRecorder()
+    var state = makeState(key: "group-summaries-sync-retry")
+    state.isCalendarSyncInFlight = true
+
+    let store = makeStore(state: state) {
+      $0.calendarSyncClient.sync = { ids in
+        await syncRecorder.record(ids)
+        return CalendarSyncResult()
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.internal(.groupSummariesResponse(.success([group])))) {
+      $0.groupMain.allGroupSummaries = [group]
+    }
+    #expect(store.state.currentUser.groups == [group])
+
+    await store.receive(\.home.internal.fetchSchedules)
+    await store.receive(\.calendar.view.refresh)
+    await store.receive(\.internal.syncCalendarAfterCurrent) {
+      $0.isCalendarSyncRetryPending = true
+    }
+    await store.receive(\.home.internal.schedulesResponse.success)
+
+    await store.send(.internal(.syncCalendarFinished(success: true))) {
+      $0.isCalendarSyncInFlight = false
+      $0.hasInitialCalendarSyncBeenScheduled = true
+      $0.isCalendarSyncRetryPending = false
+    }
+    await store.receive(\.internal.syncCalendar) {
+      $0.isCalendarSyncInFlight = true
+    }
+    await store.receive(\.internal.syncCalendarFinished) {
+      $0.isCalendarSyncInFlight = false
+    }
+    await store.finish()
+
+    #expect(await syncRecorder.value() == Set(["group-1"]))
+  }
+
   // MARK: - 탭 선택 테스트
 
   @Test("group 탭 선택 시 selectedTab 업데이트")
@@ -818,6 +909,18 @@ private extension RootTabFeatureTests {
     }
   }
 
+  actor GroupIdsArrayRecorder {
+    private var groupIds: [[String]] = []
+
+    func record(_ ids: [String]) {
+      groupIds.append(ids)
+    }
+
+    func value() -> [[String]] {
+      groupIds
+    }
+  }
+
   actor ETAUpdateRecorder {
     struct Snapshot: Equatable {
       var scheduleId: String
@@ -872,6 +975,14 @@ private extension RootTabFeatureTests {
       metadata: .init(),
       groups: groups
     )
+  }
+
+  func makeGroupInfo(
+    id: String,
+    name: String = "테스트 그룹",
+    notifications: GroupNotificationSettings? = nil
+  ) -> UserGroupInfo {
+    UserGroupInfo(id: id, name: name, notifications: notifications)
   }
 
   func makeState(
@@ -987,9 +1098,12 @@ private extension RootTabFeatureTests {
     dependencies.calendarSyncClient.syncPersonalEvents = { _ in CalendarSyncResult() }
     dependencies.analyticsClient.logEvent = { _, _ in }
     dependencies.eventKitClient.authorizationStatus = { .notDetermined }
+    dependencies.locationClient.authorizationStatus = { .notDetermined }
+    dependencies.briefingClient.generate = { _ in BriefingResult(summary: "", detail: "") }
     dependencies.personalEventClient.getActiveEvents = { _ in [] }
     dependencies.personalEventClient.getEvent = { _ in nil }
     dependencies.personalEventClient.getEventsByDateRange = { _, _ in [] }
+    dependencies.recurringPersonalEventClient.getAllEvents = { [] }
 
     dependencies.groupClient.fetchGroupSummaries = { [] }
     dependencies.groupClient.fetchGroup = { _ in group }
@@ -1002,6 +1116,7 @@ private extension RootTabFeatureTests {
         continuation.finish()
       }
     }
+    dependencies.scheduleClient.getHomeSchedules = { _, _ in [] }
     dependencies.scheduleClient.getPastSchedules = { _, _, _ in [] }
     dependencies.scheduleClient.updateETA = { _, _, _, _ in }
 

--- a/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
+++ b/Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
@@ -133,13 +133,15 @@ struct RootTabFeatureTests {
     store.exhaustivity = .off(showSkippedAssertions: false)
 
     await store.send(.internal(.groupSummariesResponse(.success([group])))) {
+      $0.currentUser.groups = [group]
       $0.groupMain.allGroupSummaries = [group]
     }
     #expect(store.state.currentUser.groups == [group])
 
-    await store.receive(\.home.internal.fetchSchedules)
+    await store.receive(\.home.view.groupMembershipChanged)
     await store.receive(\.calendar.view.refresh)
     await store.receive(\.internal.syncCalendarAfterCurrent)
+    await store.receive(\.home.internal.fetchSchedules)
     await store.receive(\.internal.syncCalendar) {
       $0.isCalendarSyncInFlight = true
     }
@@ -174,15 +176,17 @@ struct RootTabFeatureTests {
     store.exhaustivity = .off(showSkippedAssertions: false)
 
     await store.send(.internal(.groupSummariesResponse(.success([group])))) {
+      $0.currentUser.groups = [group]
       $0.groupMain.allGroupSummaries = [group]
     }
     #expect(store.state.currentUser.groups == [group])
 
-    await store.receive(\.home.internal.fetchSchedules)
+    await store.receive(\.home.view.groupMembershipChanged)
     await store.receive(\.calendar.view.refresh)
     await store.receive(\.internal.syncCalendarAfterCurrent) {
       $0.isCalendarSyncRetryPending = true
     }
+    await store.receive(\.home.internal.fetchSchedules)
     await store.receive(\.home.internal.schedulesResponse.success)
 
     await store.send(.internal(.syncCalendarFinished(success: true))) {

--- a/Tuist/ProjectDescriptionHelpers/AppConfig.swift
+++ b/Tuist/ProjectDescriptionHelpers/AppConfig.swift
@@ -16,7 +16,7 @@ public enum AppConfig {
   public static let defaultRegions = ["en", "ko"]
   
   public static let teamId = "BAC795627G"
-  public static let marketingNumber: String = "1.4.1"
+  public static let marketingNumber: String = "1.4.2"
   
   public static func buildVersion(for environment: String = "dev") -> String {
     let now = Date()


### PR DESCRIPTION
## Summary
- 앱 첫 진입 시 서버 그룹 요약을 갱신해 Home/Calendar의 그룹 일정 누락을 보강합니다.
- 그룹 목록 변경 시 Home 일정, Calendar 화면, 캘린더 동기화를 조건부 갱신하고 앱 버전을 1.4.2로 올립니다.

## 변경 유형
- [ ] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [x] chore: 설정, 빌드 등 기타 변경
- [ ] docs: 문서 수정
- [x] test: 테스트 추가/수정

## 변경 파일
- Projects/Features/RootTabFeature/Sources/RootTabFeature.swift
- Projects/Features/RootTabFeature/Tests/Sources/RootTabFeatureTests.swift
- Tuist/ProjectDescriptionHelpers/AppConfig.swift

## 스크린샷 (UI 변경 시)
N/A

## Test plan
- [x] `tuist generate`
- [x] `make test-module MODULE=RootTabFeature`
- [x] `git diff --check`

## 관련 이슈
