### PR TITLE
fix: 온보딩 재진입 방지

### DIFF
--- a/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
+++ b/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
@@ -91,12 +91,12 @@ extension AppEntry {
       case updateAlert(UpdateAlertAction)
     }
 
-    public enum UpdateAlertAction: Equatable {
+    public enum UpdateAlertAction: Equatable, Sendable {
       case updateTapped
       case laterTapped
     }
     
-    public enum ViewAction {
+    public enum ViewAction: Sendable {
       case onAppear
       case splashAnimationCompleted
       case handleDeeplink(URL)
@@ -107,9 +107,23 @@ extension AppEntry {
       case fcmToken
       case pushNotificationTap
     }
+
+    private enum ProfileCheckFailure: LocalizedError, Sendable {
+      case missingCurrentUser
+      case profileFetchFailed(String)
+
+      var errorDescription: String? {
+        switch self {
+        case .missingCurrentUser:
+          return "Current user is missing during profile check."
+        case .profileFetchFailed(let message):
+          return message
+        }
+      }
+    }
     
     @CasePathable
-    public enum InternalAction {
+    public enum InternalAction: Sendable {
       case checkVersion
       case versionCheckCompleted(VersionCheckResult)
       case recheckVersionAfterAppStore
@@ -118,7 +132,7 @@ extension AppEntry {
       case sessionCheckResponse(isAuthenticated: Bool)
       case startProfileCheck
       case profileCheckResponse(user: AuthUserSnapshot, profile: UserPrivateModel?)
-      case profileCheckFailed(Error)
+      case profileCheckFailed(any Error & Sendable)
       case checkNotificationPermission(UserPrivateModel)
       case notificationPermissionChecked(isAuthorized: Bool, user: UserPrivateModel)
       case subscribeFCMToken
@@ -244,7 +258,10 @@ extension AppEntry {
             
           case .startProfileCheck:
             return .run { send in
-              guard let user = await authClient.currentUser() else { return }
+              guard let user = await authClient.currentUser() else {
+                await send(.internal(.profileCheckFailed(ProfileCheckFailure.missingCurrentUser)))
+                return
+              }
               do {
                 let privateProfile = try await userProfileClient.getPrivateProfile(target: .me)
                 await send(.internal(.profileCheckResponse(user: user, profile: privateProfile)))
@@ -252,7 +269,9 @@ extension AppEntry {
                 if Self.isMissingProfileError(error) {
                   await send(.internal(.profileCheckResponse(user: user, profile: nil)))
                 } else {
-                  await send(.internal(.profileCheckFailed(error)))
+                  await send(.internal(
+                    .profileCheckFailed(ProfileCheckFailure.profileFetchFailed(error.localizedDescription))
+                  ))
                 }
               }
             }

--- a/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
+++ b/Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift
@@ -118,6 +118,7 @@ extension AppEntry {
       case sessionCheckResponse(isAuthenticated: Bool)
       case startProfileCheck
       case profileCheckResponse(user: AuthUserSnapshot, profile: UserPrivateModel?)
+      case profileCheckFailed(Error)
       case checkNotificationPermission(UserPrivateModel)
       case notificationPermissionChecked(isAuthorized: Bool, user: UserPrivateModel)
       case subscribeFCMToken
@@ -227,9 +228,14 @@ extension AppEntry {
             if isAuthenticated {
               return .send(.internal(.startProfileCheck))
             } else {
-              state.isFullOnboarding = true
-              state.destination = .onboardingIntro(OnboardingIntro.State())
-              analyticsClient.log(.onboardingStepViewed(step: "intro"))
+              let hasCompletedOnboarding = userDefaultsClient.boolForKey(AppConstants.UserDefaults.hasCompletedOnboarding)
+              if hasCompletedOnboarding {
+                state.destination = .auth(Auth.Feature.State())
+              } else {
+                state.isFullOnboarding = true
+                state.destination = .onboardingIntro(OnboardingIntro.State())
+                analyticsClient.log(.onboardingStepViewed(step: "intro"))
+              }
               if state.splash == .visible {
                 state.splash = .animatingOut
               }
@@ -239,8 +245,16 @@ extension AppEntry {
           case .startProfileCheck:
             return .run { send in
               guard let user = await authClient.currentUser() else { return }
-              let privateProfile = try? await userProfileClient.getPrivateProfile(target: .me)
-              await send(.internal(.profileCheckResponse(user: user, profile: privateProfile)))
+              do {
+                let privateProfile = try await userProfileClient.getPrivateProfile(target: .me)
+                await send(.internal(.profileCheckResponse(user: user, profile: privateProfile)))
+              } catch {
+                if Self.isMissingProfileError(error) {
+                  await send(.internal(.profileCheckResponse(user: user, profile: nil)))
+                } else {
+                  await send(.internal(.profileCheckFailed(error)))
+                }
+              }
             }
             
           case .profileCheckResponse(let user, let profile):
@@ -261,6 +275,14 @@ extension AppEntry {
               if state.splash == .visible {
                 state.splash = .animatingOut
               }
+            }
+            return .none
+
+          case .profileCheckFailed(let error):
+            AppLogger.auth.error("Profile check failed: \(error.localizedDescription)")
+            state.destination = .auth(Auth.Feature.State())
+            if state.splash == .visible {
+              state.splash = .animatingOut
             }
             return .none
 
@@ -521,6 +543,19 @@ extension AppEntry {
       .ifLet(\.$notificationPermission, action: \.notificationPermission) {
         NotificationPermission.Feature()
       }
+    }
+
+    private static func isMissingProfileError(_ error: Error) -> Bool {
+      if let userProfileError = error as? UserProfileError {
+        return userProfileError == .userNotFound
+      }
+
+      if let rustError = error as? RustAPIError,
+         case let .serverError(code, _) = rustError {
+        return code == "not-found"
+      }
+
+      return false
     }
   }
   

--- a/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
+++ b/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
@@ -129,10 +129,13 @@ struct AppEntryFeatureTests {
 
     await store.send(.internal(.sessionCheckResponse(isAuthenticated: true)))
     await store.receive(\.internal.startProfileCheck)
+    await store.receive(\.internal.profileCheckFailed) {
+      $0.splash = .animatingOut
+    }
   }
 
-  @Test("startProfileCheck currentUser=nil 이면 종료")
-  func startProfileCheck_withoutUser_doesNothing() async {
+  @Test("startProfileCheck currentUser=nil 이면 auth로 이동하고 splash 종료")
+  func startProfileCheck_withoutUser_routesToAuth() async {
     let store = TestStore(initialState: AppEntry.Feature.State()) {
       AppEntry.Feature()
     } withDependencies: {
@@ -140,6 +143,10 @@ struct AppEntryFeatureTests {
     }
 
     await store.send(.internal(.startProfileCheck))
+    await store.receive(\.internal.profileCheckFailed) {
+      $0.splash = .animatingOut
+    }
+    #expect(store.state.destinationType == .auth)
   }
 
   @Test("startProfileCheck currentUser 존재 시 profileCheckResponse 처리")
@@ -336,6 +343,9 @@ struct AppEntryFeatureTests {
       $0.providerProfileImageURL = profileImageURL
     }
     await store.receive(\.internal.startProfileCheck)
+    await store.receive(\.internal.profileCheckFailed) {
+      $0.splash = .animatingOut
+    }
   }
 
   @Test("profileCheckResponse 기존 사용자 + pending 없으면 메인 전환만")

--- a/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
+++ b/Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift
@@ -170,6 +170,55 @@ struct AppEntryFeatureTests {
     #expect(store.state.destinationType == .main)
   }
 
+  @Test("startProfileCheck 프로필 not-found면 신규 사용자로 처리")
+  func startProfileCheck_profileNotFound_routesToProfileSetup() async {
+    let authUser = makeAuthUser(
+      uid: "firebase-new-from-error",
+      displayName: "신규 사용자",
+      photoURL: nil
+    )
+    let providerURL = URL(string: "https://example.com/provider-profile.png")!
+    var state = AppEntry.Feature.State()
+    state.providerProfileImageURL = providerURL
+
+    let store = TestStore(initialState: state) {
+      AppEntry.Feature()
+    } withDependencies: {
+      $0.authClient.currentUser = { authUser }
+      $0.userProfileClient.getPrivateProfile = { _ in
+        throw RustAPIError.serverError(code: "not-found", message: "사용자를 찾을 수 없습니다")
+      }
+    }
+
+    await store.send(.internal(.startProfileCheck))
+    await store.receive(\.internal.profileCheckResponse) {
+      var expectedProfile = AppEntry.ProfileSetup.State()
+      expectedProfile.inject(user: authUser, providerProfileImageURL: providerURL)
+      $0.destination = .profile(expectedProfile)
+      $0.splash = .animatingOut
+    }
+  }
+
+  @Test("startProfileCheck 프로필 조회 실패가 not-found가 아니면 profile setup으로 보내지 않음")
+  func startProfileCheck_profileFetchFailure_doesNotRouteToProfileSetup() async {
+    enum ProfileFetchError: Error { case network }
+
+    let authUser = makeAuthUser(uid: "firebase-profile-failure")
+
+    let store = TestStore(initialState: AppEntry.Feature.State()) {
+      AppEntry.Feature()
+    } withDependencies: {
+      $0.authClient.currentUser = { authUser }
+      $0.userProfileClient.getPrivateProfile = { _ in throw ProfileFetchError.network }
+    }
+
+    await store.send(.internal(.startProfileCheck))
+    await store.receive(\.internal.profileCheckFailed) {
+      $0.splash = .animatingOut
+    }
+    #expect(store.state.destinationType == .auth)
+  }
+
   // MARK: - Update Alert 테스트
 
   @Test("강제 업데이트 필요 시 updateAlert 설정")
@@ -528,6 +577,23 @@ struct AppEntryFeatureTests {
     }
   }
 
+  @Test("sessionCheckResponse 비인증 + 온보딩 완료 → auth")
+  func sessionCheck_unauthenticated_onboardingCompleted_showsAuth() async {
+    let store = TestStore(initialState: AppEntry.Feature.State()) {
+      AppEntry.Feature()
+    } withDependencies: {
+      $0.userDefaultsClient.boolForKey = { key in
+        key == AppConstants.UserDefaults.hasCompletedOnboarding
+      }
+    }
+
+    await store.send(.internal(.sessionCheckResponse(isAuthenticated: false))) {
+      $0.splash = .animatingOut
+    }
+    #expect(store.state.destinationType == .auth)
+    #expect(store.state.isFullOnboarding == false)
+  }
+
   @Test("onboardingIntro.delegate.introCompleted → auth 화면으로 전환")
   func onboardingIntroCompleted_showsAuth() async {
     var state = AppEntry.Feature.State()
@@ -835,7 +901,7 @@ struct AppEntryFeatureTests {
 
 private extension AppEntryFeatureTests {
 
-  /// 비인증 상태의 continueAppFlow → sessionCheck → auth 전환 체인 수신 후 구독 정리
+  /// 비인증 + 온보딩 완료 상태의 continueAppFlow → sessionCheck → auth 유지 체인 수신 후 구독 정리
   func receiveContinueAppFlowUnauthenticated(
     _ store: TestStoreOf<AppEntry.Feature>
   ) async {
@@ -844,8 +910,6 @@ private extension AppEntryFeatureTests {
     await store.receive(\.internal.subscribeFCMToken)
     await store.receive(\.internal.subscribePushNotificationTap)
     await store.receive(\.internal.sessionCheckResponse) {
-      $0.isFullOnboarding = true
-      $0.destination = .onboardingIntro(AppEntry.OnboardingIntro.State())
       $0.splash = .animatingOut
     }
     await store.send(.internal(.cancelSubscriptions))


### PR DESCRIPTION
## Summary
- 세션이 없더라도 온보딩 완료 사용자는 소개 온보딩이 아니라 로그인 화면으로 이동하도록 수정했습니다.
- 프로필 조회 실패를 신규 사용자로 오인하지 않도록 `not-found`만 프로필 설정으로 처리하고, 그 외 오류는 auth로 되돌립니다.

## 변경 유형
- [ ] feat: 새로운 기능
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
- [ ] chore: 설정, 빌드 등 기타 변경
- [ ] docs: 문서 수정
- [x] test: 테스트 추가/수정

## 변경 파일
- `Projects/Features/AppEntryFeature/Sources/AppEntryFeature.swift`
- `Projects/Features/AppEntryFeature/Tests/Sources/AppEntryFeatureTests.swift`

## 스크린샷 (UI 변경 시)
N/A

## Test plan
- [x] `make test-module MODULE=AppEntryFeature`
- [x] 기존 AppEntry 딥링크/온보딩/ProfileSetup 테스트 통과

## 관련 이슈
