### PR TITLE
fix: 개인 일정 키보드 가림 수정

### DIFF
--- a/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventView.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventView.swift
@@ -11,6 +11,7 @@ extension CreatePersonalEvent {
   public struct RootView: View {
     @Bindable private var store: StoreOf<Feature>
     @FocusState private var focusedField: Field?
+    @State private var descriptionFocusRequest = 0
     private let dismissButtonVisibility: DismissButtonVisibility
 
     public enum DismissButtonVisibility {
@@ -119,6 +120,14 @@ extension CreatePersonalEvent {
           guard let newValue else { return }
           withAnimation(.easeInOut(duration: 0.2)) {
             proxy.scrollTo(newValue, anchor: .center)
+          }
+        }
+        .onChange(of: descriptionFocusRequest) { _, _ in
+          Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(250))
+            withAnimation(.easeInOut(duration: 0.2)) {
+              proxy.scrollTo(Field.description, anchor: .center)
+            }
           }
         }
       }
@@ -487,7 +496,11 @@ extension CreatePersonalEvent {
         blocks: Binding(
           get: { store.event.descriptionBlocks },
           set: { store.send(.view(.descriptionBlocksChanged($0))) }
-        )
+        ),
+        onFocusChanged: { isFocused in
+          guard isFocused else { return }
+          descriptionFocusRequest += 1
+        }
       )
       .padding(16)
       .adaptiveGlassCard()

--- a/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventView.swift
+++ b/Projects/Features/CreateScheduleFeature/Sources/PersonalEvent/CreatePersonalEventView.swift
@@ -11,7 +11,6 @@ extension CreatePersonalEvent {
   public struct RootView: View {
     @Bindable private var store: StoreOf<Feature>
     @FocusState private var focusedField: Field?
-    @State private var descriptionFocusRequest = 0
     private let dismissButtonVisibility: DismissButtonVisibility
 
     public enum DismissButtonVisibility {
@@ -120,14 +119,6 @@ extension CreatePersonalEvent {
           guard let newValue else { return }
           withAnimation(.easeInOut(duration: 0.2)) {
             proxy.scrollTo(newValue, anchor: .center)
-          }
-        }
-        .onChange(of: descriptionFocusRequest) { _, _ in
-          Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(250))
-            withAnimation(.easeInOut(duration: 0.2)) {
-              proxy.scrollTo(Field.description, anchor: .center)
-            }
           }
         }
       }
@@ -496,11 +487,7 @@ extension CreatePersonalEvent {
         blocks: Binding(
           get: { store.event.descriptionBlocks },
           set: { store.send(.view(.descriptionBlocksChanged($0))) }
-        ),
-        onFocusChanged: { isFocused in
-          guard isFocused else { return }
-          descriptionFocusRequest += 1
-        }
+        )
       )
       .padding(16)
       .adaptiveGlassCard()

--- a/Projects/Shared/Sources/UI/Components/DescriptionBlockEditor.swift
+++ b/Projects/Shared/Sources/UI/Components/DescriptionBlockEditor.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct DescriptionBlockEditor: View {
   @Binding public var blocks: [DescriptionBlock]
   public var characterLimit: Int
+  public var onFocusChanged: ((Bool) -> Void)?
   @FocusState private var focusedItem: ItemFocus?
 
   private struct ItemFocus: Hashable {
@@ -12,9 +13,14 @@ public struct DescriptionBlockEditor: View {
     let itemIndex: Int
   }
 
-  public init(blocks: Binding<[DescriptionBlock]>, characterLimit: Int = 500) {
+  public init(
+    blocks: Binding<[DescriptionBlock]>,
+    characterLimit: Int = 500,
+    onFocusChanged: ((Bool) -> Void)? = nil
+  ) {
     self._blocks = blocks
     self.characterLimit = characterLimit
+    self.onFocusChanged = onFocusChanged
   }
 
   // 총 글자 수 계산 (사용자 입력 텍스트만)
@@ -58,6 +64,7 @@ public struct DescriptionBlockEditor: View {
         }
       }
       .onChange(of: focusedItem) { _, newItem in
+        onFocusChanged?(newItem != nil)
         guard let newItem else { return }
         withAnimation(.easeInOut(duration: 0.2)) {
           proxy.scrollTo("block-\(newItem.blockIndex)-item-\(newItem.itemIndex)", anchor: .center)
@@ -171,6 +178,7 @@ public struct DescriptionBlockEditor: View {
     .id("block-\(index)-item-0")
     .onChange(of: textContent) { _, _ in
       guard focusedItem == ItemFocus(blockIndex: index, itemIndex: 0) else { return }
+      onFocusChanged?(true)
       Task { @MainActor in
         withAnimation(.easeInOut(duration: 0.15)) {
           proxy.scrollTo("block-\(index)-item-0", anchor: .bottom)

--- a/Projects/Shared/Sources/UI/Components/DescriptionBlockEditor.swift
+++ b/Projects/Shared/Sources/UI/Components/DescriptionBlockEditor.swift
@@ -5,7 +5,6 @@ import SwiftUI
 public struct DescriptionBlockEditor: View {
   @Binding public var blocks: [DescriptionBlock]
   public var characterLimit: Int
-  public var onFocusChanged: ((Bool) -> Void)?
   @FocusState private var focusedItem: ItemFocus?
 
   private struct ItemFocus: Hashable {
@@ -15,12 +14,10 @@ public struct DescriptionBlockEditor: View {
 
   public init(
     blocks: Binding<[DescriptionBlock]>,
-    characterLimit: Int = 500,
-    onFocusChanged: ((Bool) -> Void)? = nil
+    characterLimit: Int = 500
   ) {
     self._blocks = blocks
     self.characterLimit = characterLimit
-    self.onFocusChanged = onFocusChanged
   }
 
   // 총 글자 수 계산 (사용자 입력 텍스트만)
@@ -64,7 +61,6 @@ public struct DescriptionBlockEditor: View {
         }
       }
       .onChange(of: focusedItem) { _, newItem in
-        onFocusChanged?(newItem != nil)
         guard let newItem else { return }
         withAnimation(.easeInOut(duration: 0.2)) {
           proxy.scrollTo("block-\(newItem.blockIndex)-item-\(newItem.itemIndex)", anchor: .center)
@@ -178,7 +174,6 @@ public struct DescriptionBlockEditor: View {
     .id("block-\(index)-item-0")
     .onChange(of: textContent) { _, _ in
       guard focusedItem == ItemFocus(blockIndex: index, itemIndex: 0) else { return }
-      onFocusChanged?(true)
       Task { @MainActor in
         withAnimation(.easeInOut(duration: 0.15)) {
           proxy.scrollTo("block-\(index)-item-0", anchor: .bottom)

--- a/Projects/Shared/Sources/UI/Components/StepSheetContainer.swift
+++ b/Projects/Shared/Sources/UI/Components/StepSheetContainer.swift
@@ -79,7 +79,6 @@ public struct StepSheetContainer<
       }
       .frame(height: geometry.size.height)
     }
-    .ignoresSafeArea(.keyboard, edges: .bottom)
     .keyboardDismissToolbar(iconColor: .secondary)
     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { notification in
       updateKeyboardPresentation(notification)

--- a/Projects/Shared/Sources/UI/Components/StepSheetContainer.swift
+++ b/Projects/Shared/Sources/UI/Components/StepSheetContainer.swift
@@ -39,6 +39,7 @@ public struct StepSheetContainer<
 
   @State private var isDismissPressed = false
   @State private var isKeyboardPresented = false
+  @State private var keyboardHeight: CGFloat = 0
 
   public init(
     title: String,
@@ -79,6 +80,7 @@ public struct StepSheetContainer<
       }
       .frame(height: geometry.size.height)
     }
+    .ignoresSafeArea(.keyboard, edges: .bottom)
     .keyboardDismissToolbar(iconColor: .secondary)
     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { notification in
       updateKeyboardPresentation(notification)
@@ -88,6 +90,7 @@ public struct StepSheetContainer<
       let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0.25
       withAnimation(.easeInOut(duration: duration)) {
         isKeyboardPresented = false
+        keyboardHeight = 0
       }
     }
   }
@@ -147,7 +150,10 @@ public struct StepSheetContainer<
 
   @ViewBuilder
   private var bottomFixedArea: some View {
-    if !isKeyboardPresented {
+    if isKeyboardPresented {
+      Color.clear
+        .frame(height: keyboardHeight)
+    } else {
       VStack(spacing: 12) {
         floatingContent()
           .padding(.horizontal, 16)
@@ -179,7 +185,10 @@ public struct StepSheetContainer<
 
     guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
       if isKeyboardPresented {
-        withAnimation(.easeInOut(duration: duration)) { isKeyboardPresented = false }
+        withAnimation(.easeInOut(duration: duration)) {
+          isKeyboardPresented = false
+          keyboardHeight = 0
+        }
       }
       return
     }
@@ -188,9 +197,12 @@ public struct StepSheetContainer<
       .compactMap { $0 as? UIWindowScene }
       .first?.screen.bounds.height ?? endFrame.height
     let isVisible = endFrame.minY < screenHeight
-    if isKeyboardPresented != isVisible {
+    let newHeight = isVisible ? max(0, screenHeight - endFrame.minY) : 0
+
+    if isKeyboardPresented != isVisible || keyboardHeight != newHeight {
       withAnimation(.easeInOut(duration: duration)) {
         isKeyboardPresented = isVisible
+        keyboardHeight = newHeight
       }
     }
   }


### PR DESCRIPTION
## Summary
- Stop `StepSheetContainer` from fighting system keyboard layout by managing keyboard height as a bottom inset while the keyboard is visible.
- Keep the bottom action area hidden during keyboard input without causing the sheet to jump up and down.
- Preserve existing `DescriptionBlockEditor` internal scroll behavior without adding parent-level delayed scrolling.

## Tests
- `make test-module MODULE=CreateScheduleFeature`

## Notes
- `Projects/Shared/Resources/Localizable.xcstrings` has a pre-existing local change and is intentionally not included in this PR.